### PR TITLE
feat: implement session lifecycle management with REPL

### DIFF
--- a/src/NimbusStation.Cli/Commands/CommandRegistry.cs
+++ b/src/NimbusStation.Cli/Commands/CommandRegistry.cs
@@ -1,0 +1,49 @@
+using NimbusStation.Core.Commands;
+
+namespace NimbusStation.Cli.Commands;
+
+/// <summary>
+/// Registry for discovering and dispatching commands.
+/// </summary>
+public sealed class CommandRegistry
+{
+    private readonly Dictionary<string, ICommand> _commands = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Registers a command with the registry.
+    /// </summary>
+    /// <param name="command">The command to register.</param>
+    public void Register(ICommand command)
+    {
+        _commands[command.Name] = command;
+    }
+
+    /// <summary>
+    /// Gets a command by name.
+    /// </summary>
+    /// <param name="name">The command name.</param>
+    /// <returns>The command, or null if not found.</returns>
+    public ICommand? GetCommand(string name)
+    {
+        return _commands.GetValueOrDefault(name);
+    }
+
+    /// <summary>
+    /// Gets all registered commands.
+    /// </summary>
+    /// <returns>An enumerable of all commands.</returns>
+    public IEnumerable<ICommand> GetAllCommands()
+    {
+        return _commands.Values;
+    }
+
+    /// <summary>
+    /// Checks if a command with the specified name exists.
+    /// </summary>
+    /// <param name="name">The command name.</param>
+    /// <returns>True if the command exists, false otherwise.</returns>
+    public bool HasCommand(string name)
+    {
+        return _commands.ContainsKey(name);
+    }
+}

--- a/src/NimbusStation.Cli/Commands/SessionCommand.cs
+++ b/src/NimbusStation.Cli/Commands/SessionCommand.cs
@@ -1,0 +1,259 @@
+using NimbusStation.Core.Commands;
+using NimbusStation.Core.Session;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Commands;
+
+/// <summary>
+/// Command for managing sessions (start, list, leave, resume, delete, status).
+/// </summary>
+public sealed class SessionCommand : ICommand
+{
+    private readonly ISessionService _sessionService;
+
+    /// <inheritdoc/>
+    public string Name => "session";
+
+    /// <inheritdoc/>
+    public string Description => "Manage investigation sessions";
+
+    /// <inheritdoc/>
+    public string Usage => "session <start|list|leave|resume|delete|status> [session-name]";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionCommand"/> class.
+    /// </summary>
+    /// <param name="sessionService">The session service.</param>
+    public SessionCommand(ISessionService sessionService)
+    {
+        _sessionService = sessionService;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default)
+    {
+        if (args.Length == 0)
+        {
+            return CommandResult.Error($"Usage: {Usage}");
+        }
+
+        var subcommand = args[0].ToLowerInvariant();
+        var subArgs = args.Skip(1).ToArray();
+
+        return subcommand switch
+        {
+            "start" => await HandleStartAsync(subArgs, context, cancellationToken),
+            "list" or "ls" => await HandleListAsync(cancellationToken),
+            "leave" => HandleLeave(context),
+            "resume" => await HandleResumeAsync(subArgs, context, cancellationToken),
+            "delete" or "rm" => await HandleDeleteAsync(subArgs, cancellationToken),
+            "status" => HandleStatus(context),
+            _ => CommandResult.Error($"Unknown subcommand '{subcommand}'. Usage: {Usage}")
+        };
+    }
+
+    private async Task<CommandResult> HandleStartAsync(string[] args, CommandContext context, CancellationToken cancellationToken)
+    {
+        if (args.Length == 0)
+        {
+            return CommandResult.Error("Usage: session start <session-name>");
+        }
+
+        var sessionName = args[0];
+
+        try
+        {
+            // Check if session exists before starting to determine the action message
+            var existed = _sessionService.SessionExists(sessionName);
+            var session = await _sessionService.StartSessionAsync(sessionName, cancellationToken);
+            context.CurrentSession = session;
+
+            var action = existed ? "Resumed" : "Started";
+
+            AnsiConsole.MarkupLine($"[green]{action} session[/] [cyan]{session.TicketId}[/]");
+            AnsiConsole.MarkupLine($"[dim]Session directory: {_sessionService.GetSessionDirectory(sessionName)}[/]");
+
+            return CommandResult.Ok(session);
+        }
+        catch (InvalidSessionNameException ex)
+        {
+            return CommandResult.Error(ex.Message);
+        }
+    }
+
+    private async Task<CommandResult> HandleListAsync(CancellationToken cancellationToken)
+    {
+        var sessions = await _sessionService.ListSessionsAsync(cancellationToken);
+
+        if (sessions.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]No sessions found. Use 'session start <name>' to create one.[/]");
+            return CommandResult.Ok();
+        }
+
+        var table = new Table();
+        table.AddColumn(new TableColumn("[bold]Session[/]").LeftAligned());
+        table.AddColumn(new TableColumn("[bold]Created[/]").LeftAligned());
+        table.AddColumn(new TableColumn("[bold]Last Accessed[/]").LeftAligned());
+        table.AddColumn(new TableColumn("[bold]Context[/]").LeftAligned());
+
+        foreach (var session in sessions)
+        {
+            var contextInfo = GetContextSummary(session.ActiveContext);
+            table.AddRow(
+                $"[cyan]{session.TicketId}[/]",
+                FormatTimestamp(session.CreatedAt),
+                FormatTimestamp(session.LastAccessedAt),
+                contextInfo);
+        }
+
+        AnsiConsole.Write(table);
+        return CommandResult.Ok(sessions);
+    }
+
+    private static CommandResult HandleLeave(CommandContext context)
+    {
+        if (context.CurrentSession is null)
+        {
+            return CommandResult.Error("No active session to leave.");
+        }
+
+        var sessionName = context.CurrentSession.TicketId;
+        context.CurrentSession = null;
+
+        AnsiConsole.MarkupLine($"[yellow]Left session[/] [cyan]{sessionName}[/]");
+        return CommandResult.Ok();
+    }
+
+    private async Task<CommandResult> HandleResumeAsync(string[] args, CommandContext context, CancellationToken cancellationToken)
+    {
+        if (args.Length == 0)
+        {
+            return CommandResult.Error("Usage: session resume <session-name>");
+        }
+
+        var sessionName = args[0];
+
+        try
+        {
+            var session = await _sessionService.ResumeSessionAsync(sessionName, cancellationToken);
+            context.CurrentSession = session;
+
+            AnsiConsole.MarkupLine($"[green]Resumed session[/] [cyan]{session.TicketId}[/]");
+            return CommandResult.Ok(session);
+        }
+        catch (SessionNotFoundException ex)
+        {
+            return CommandResult.Error(ex.Message);
+        }
+    }
+
+    private async Task<CommandResult> HandleDeleteAsync(string[] args, CancellationToken cancellationToken)
+    {
+        if (args.Length == 0)
+        {
+            return CommandResult.Error("Usage: session delete <session-name>");
+        }
+
+        var sessionName = args[0];
+
+        if (!_sessionService.SessionExists(sessionName))
+        {
+            return CommandResult.Error($"Session '{sessionName}' not found.");
+        }
+
+        // Confirmation prompt
+        var confirmed = AnsiConsole.Confirm(
+            $"[yellow]Delete session '[cyan]{sessionName}[/]' and all its data?[/]",
+            defaultValue: false);
+
+        if (!confirmed)
+        {
+            AnsiConsole.MarkupLine("[dim]Deletion cancelled.[/]");
+            return CommandResult.Ok();
+        }
+
+        try
+        {
+            await _sessionService.DeleteSessionAsync(sessionName, cancellationToken);
+            AnsiConsole.MarkupLine($"[red]Deleted session[/] [cyan]{sessionName}[/]");
+            return CommandResult.Ok();
+        }
+        catch (SessionNotFoundException ex)
+        {
+            return CommandResult.Error(ex.Message);
+        }
+    }
+
+    private static CommandResult HandleStatus(CommandContext context)
+    {
+        if (context.CurrentSession is null)
+        {
+            AnsiConsole.MarkupLine("[dim]No active session. Use 'session start <name>' to begin.[/]");
+            return CommandResult.Ok();
+        }
+
+        var session = context.CurrentSession;
+
+        var panel = new Panel(new Rows(
+            new Markup($"[bold]Session:[/] [cyan]{session.TicketId}[/]"),
+            new Markup($"[bold]Created:[/] {FormatTimestamp(session.CreatedAt)}"),
+            new Markup($"[bold]Last Accessed:[/] {FormatTimestamp(session.LastAccessedAt)}"),
+            new Markup($"[bold]Cosmos Alias:[/] {session.ActiveContext?.ActiveCosmosAlias ?? "[dim]none[/]"}"),
+            new Markup($"[bold]Blob Alias:[/] {session.ActiveContext?.ActiveBlobAlias ?? "[dim]none[/]"}")
+        ))
+        {
+            Header = new PanelHeader("[bold green]Session Status[/]"),
+            Border = BoxBorder.Rounded
+        };
+
+        AnsiConsole.Write(panel);
+        return CommandResult.Ok(session);
+    }
+
+    private static string GetContextSummary(SessionContext? context)
+    {
+        if (context is null)
+        {
+            return "[dim]none[/]";
+        }
+
+        var parts = new List<string>();
+        if (context.ActiveCosmosAlias is not null)
+        {
+            parts.Add($"cosmos:{context.ActiveCosmosAlias}");
+        }
+        if (context.ActiveBlobAlias is not null)
+        {
+            parts.Add($"blob:{context.ActiveBlobAlias}");
+        }
+
+        return parts.Count > 0 ? string.Join(", ", parts) : "[dim]none[/]";
+    }
+
+    private static string FormatTimestamp(DateTimeOffset timestamp)
+    {
+        var local = timestamp.ToLocalTime();
+        var now = DateTimeOffset.Now;
+        var diff = now - local;
+
+        if (diff.TotalMinutes < 1)
+        {
+            return "just now";
+        }
+        if (diff.TotalHours < 1)
+        {
+            return $"{(int)diff.TotalMinutes}m ago";
+        }
+        if (diff.TotalDays < 1)
+        {
+            return $"{(int)diff.TotalHours}h ago";
+        }
+        if (diff.TotalDays < 7)
+        {
+            return $"{(int)diff.TotalDays}d ago";
+        }
+
+        return local.ToString("yyyy-MM-dd HH:mm");
+    }
+}

--- a/src/NimbusStation.Cli/NimbusStation.Cli.csproj
+++ b/src/NimbusStation.Cli/NimbusStation.Cli.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
 

--- a/src/NimbusStation.Cli/Program.cs
+++ b/src/NimbusStation.Cli/Program.cs
@@ -1,4 +1,10 @@
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NimbusStation.Cli.Commands;
+using NimbusStation.Cli.Repl;
+using NimbusStation.Core.Session;
+using NimbusStation.Infrastructure.Sessions;
 using Spectre.Console;
 
 namespace NimbusStation.Cli;
@@ -8,15 +14,54 @@ namespace NimbusStation.Cli;
 /// </summary>
 public static class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        if (args.Length > 0 && (args[0] == "--version" || args[0] == "-v"))
+        if (args.Length > 0 && args[0] is "--version" or "-v")
         {
             PrintVersion();
             return;
         }
 
         PrintBanner();
+
+        var services = ConfigureServices();
+        var repl = services.GetRequiredService<ReplLoop>();
+
+        using var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+
+        await repl.RunAsync(cts.Token);
+    }
+
+    private static ServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        // Logging
+        services.AddLogging(builder => builder
+            .SetMinimumLevel(LogLevel.Warning)
+            .AddConsole());
+
+        // Core services
+        services.AddSingleton<ISessionService, SessionService>();
+
+        // Commands
+        services.AddSingleton<SessionCommand>();
+        services.AddSingleton<CommandRegistry>(sp =>
+        {
+            var registry = new CommandRegistry();
+            registry.Register(sp.GetRequiredService<SessionCommand>());
+            return registry;
+        });
+
+        // REPL
+        services.AddSingleton<ReplLoop>();
+
+        return services.BuildServiceProvider();
     }
 
     private static void PrintBanner()
@@ -30,10 +75,8 @@ public static class Program
         AnsiConsole.WriteLine();
     }
 
-    private static void PrintVersion()
-    {
+    private static void PrintVersion() =>
         AnsiConsole.MarkupLine($"[cyan]ns[/] [yellow]{GetVersion()}[/]");
-    }
 
     /// <summary>
     /// Gets the application version from the assembly's informational version attribute.
@@ -46,18 +89,10 @@ public static class Program
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
             .InformationalVersion;
 
-        // Strip the source revision hash if present (e.g., "0.1.0-alpha+abc123" -> "0.1.0-alpha")
-        if (informationalVersion is not null)
-        {
-            int plusIndex = informationalVersion.IndexOf('+');
-            if (plusIndex > 0)
-            {
-                return informationalVersion[..plusIndex];
-            }
-            return informationalVersion;
-        }
+        if (informationalVersion is null)
+            return assembly.GetName().Version?.ToString() ?? "unknown";
 
-        // Fallback to assembly version
-        return assembly.GetName().Version?.ToString() ?? "unknown";
+        var plusIndex = informationalVersion.IndexOf('+');
+        return plusIndex > 0 ? informationalVersion[..plusIndex] : informationalVersion;
     }
 }

--- a/src/NimbusStation.Cli/Repl/InputParser.cs
+++ b/src/NimbusStation.Cli/Repl/InputParser.cs
@@ -1,0 +1,106 @@
+using System.Text;
+
+namespace NimbusStation.Cli.Repl;
+
+/// <summary>
+/// Parses command-line input into command name and arguments.
+/// Handles quoted strings and basic escape sequences.
+/// </summary>
+public static class InputParser
+{
+    /// <summary>
+    /// Parses an input line into tokens (command name and arguments).
+    /// </summary>
+    /// <param name="input">The raw input string.</param>
+    /// <returns>An array of tokens, or empty if input is empty/whitespace.</returns>
+    public static string[] Parse(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return [];
+        }
+
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var inQuote = false;
+        var quoteChar = '\0';
+        var escaped = false;
+
+        foreach (var c in input)
+        {
+            if (escaped)
+            {
+                current.Append(c);
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (inQuote)
+            {
+                if (c == quoteChar)
+                {
+                    inQuote = false;
+                    quoteChar = '\0';
+                }
+                else
+                {
+                    current.Append(c);
+                }
+                continue;
+            }
+
+            if (c is '"' or '\'')
+            {
+                inQuote = true;
+                quoteChar = c;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c))
+            {
+                if (current.Length > 0)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        // Add final token if any
+        if (current.Length > 0)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens.ToArray();
+    }
+
+    /// <summary>
+    /// Extracts the command name from parsed tokens.
+    /// </summary>
+    /// <param name="tokens">The parsed tokens.</param>
+    /// <returns>The command name, or null if no tokens.</returns>
+    public static string? GetCommandName(string[] tokens)
+    {
+        return tokens.Length > 0 ? tokens[0] : null;
+    }
+
+    /// <summary>
+    /// Extracts the arguments (everything after the command name) from parsed tokens.
+    /// </summary>
+    /// <param name="tokens">The parsed tokens.</param>
+    /// <returns>The arguments array.</returns>
+    public static string[] GetArguments(string[] tokens)
+    {
+        return tokens.Length > 1 ? tokens[1..] : [];
+    }
+}

--- a/src/NimbusStation.Cli/Repl/ReplLoop.cs
+++ b/src/NimbusStation.Cli/Repl/ReplLoop.cs
@@ -1,0 +1,142 @@
+using NimbusStation.Cli.Commands;
+using NimbusStation.Core.Commands;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Repl;
+
+/// <summary>
+/// The main Read-Eval-Print Loop for Nimbus Station.
+/// </summary>
+public sealed class ReplLoop
+{
+    private readonly CommandRegistry _commandRegistry;
+    private readonly CommandContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplLoop"/> class.
+    /// </summary>
+    /// <param name="commandRegistry">The command registry.</param>
+    public ReplLoop(CommandRegistry commandRegistry)
+    {
+        _commandRegistry = commandRegistry;
+        _context = new CommandContext();
+    }
+
+    /// <summary>
+    /// Runs the REPL loop until the user exits.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var input = AnsiConsole.Prompt(
+                new TextPrompt<string>(GetPrompt())
+                    .AllowEmpty());
+
+            if (string.IsNullOrWhiteSpace(input))
+                continue;
+
+            var tokens = InputParser.Parse(input);
+            var commandName = InputParser.GetCommandName(tokens);
+
+            if (commandName is null)
+                continue;
+
+            if (IsExitCommand(commandName))
+            {
+                AnsiConsole.MarkupLine("[dim]Goodbye![/]");
+                break;
+            }
+
+            if (IsHelpCommand(commandName))
+            {
+                ShowHelp(tokens);
+                continue;
+            }
+
+            var command = _commandRegistry.GetCommand(commandName);
+            if (command is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Unknown command:[/] {Markup.Escape(commandName)}");
+                AnsiConsole.MarkupLine("[dim]Type 'help' for available commands.[/]");
+                continue;
+            }
+
+            try
+            {
+                var args = InputParser.GetArguments(tokens);
+                var result = await command.ExecuteAsync(args, _context, cancellationToken);
+
+                if (!result.Success && result.Message is not null)
+                    AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(result.Message)}");
+            }
+            catch (OperationCanceledException)
+            {
+                AnsiConsole.MarkupLine("[yellow]Command cancelled.[/]");
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(ex.Message)}");
+#if DEBUG
+                AnsiConsole.WriteException(ex);
+#endif
+            }
+        }
+    }
+
+    private string GetPrompt() =>
+        _context.CurrentSession is { } session
+            ? $"[green]ns[/][[[cyan]{Markup.Escape(session.TicketId)}[/]]]\u203a "
+            : "[green]ns[/]\u203a ";
+
+    private static bool IsExitCommand(string command) =>
+        command.Equals("exit", StringComparison.OrdinalIgnoreCase) ||
+        command.Equals("quit", StringComparison.OrdinalIgnoreCase) ||
+        command.Equals("q", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsHelpCommand(string command) =>
+        command.Equals("help", StringComparison.OrdinalIgnoreCase) ||
+        command.Equals("?", StringComparison.OrdinalIgnoreCase);
+
+    private void ShowHelp(string[] tokens)
+    {
+        var args = InputParser.GetArguments(tokens);
+
+        if (args.Length > 0)
+        {
+            var commandName = args[0];
+            var command = _commandRegistry.GetCommand(commandName);
+
+            if (command is null)
+            {
+                AnsiConsole.MarkupLine($"[red]Unknown command:[/] {Markup.Escape(commandName)}");
+                return;
+            }
+
+            AnsiConsole.MarkupLine($"[bold]{command.Name}[/] - {command.Description}");
+            AnsiConsole.MarkupLine($"[dim]Usage:[/] {command.Usage}");
+            return;
+        }
+
+        AnsiConsole.MarkupLine("[bold]Available Commands:[/]");
+        AnsiConsole.WriteLine();
+
+        var table = new Table()
+            .Border(TableBorder.None)
+            .HideHeaders();
+
+        table.AddColumn("Command");
+        table.AddColumn("Description");
+
+        foreach (var command in _commandRegistry.GetAllCommands().OrderBy(c => c.Name))
+            table.AddRow($"[cyan]{command.Name}[/]", command.Description);
+
+        table.AddRow("[cyan]help[/]", "Show this help message");
+        table.AddRow("[cyan]exit[/]", "Exit the REPL");
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[dim]Type 'help <command>' for more information about a specific command.[/]");
+    }
+}

--- a/src/NimbusStation.Core/Commands/CommandContext.cs
+++ b/src/NimbusStation.Core/Commands/CommandContext.cs
@@ -1,0 +1,35 @@
+using NimbusStation.Core.Session;
+
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// Provides context for command execution, including the current session state.
+/// </summary>
+public sealed class CommandContext
+{
+    /// <summary>
+    /// Gets or sets the currently active session, if any.
+    /// </summary>
+    public Session.Session? CurrentSession { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether a session is currently active.
+    /// </summary>
+    public bool HasActiveSession => CurrentSession is not null;
+
+    /// <summary>
+    /// Creates a new command context with no active session.
+    /// </summary>
+    public CommandContext()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new command context with the specified session.
+    /// </summary>
+    /// <param name="session">The current session.</param>
+    public CommandContext(Session.Session? session)
+    {
+        CurrentSession = session;
+    }
+}

--- a/src/NimbusStation.Core/Commands/CommandResult.cs
+++ b/src/NimbusStation.Core/Commands/CommandResult.cs
@@ -1,0 +1,32 @@
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// Represents the result of executing a command.
+/// </summary>
+/// <param name="Success">Whether the command executed successfully.</param>
+/// <param name="Message">An optional message to display to the user.</param>
+/// <param name="Data">Optional data returned by the command.</param>
+public sealed record CommandResult(bool Success, string? Message = null, object? Data = null)
+{
+    /// <summary>
+    /// Creates a successful result with an optional message.
+    /// </summary>
+    /// <param name="message">The success message.</param>
+    /// <returns>A successful command result.</returns>
+    public static CommandResult Ok(string? message = null) => new(true, message);
+
+    /// <summary>
+    /// Creates a successful result with data.
+    /// </summary>
+    /// <param name="data">The data to return.</param>
+    /// <param name="message">An optional message.</param>
+    /// <returns>A successful command result with data.</returns>
+    public static CommandResult Ok(object data, string? message = null) => new(true, message, data);
+
+    /// <summary>
+    /// Creates a failed result with an error message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>A failed command result.</returns>
+    public static CommandResult Error(string message) => new(false, message);
+}

--- a/src/NimbusStation.Core/Commands/ICommand.cs
+++ b/src/NimbusStation.Core/Commands/ICommand.cs
@@ -1,0 +1,31 @@
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// Represents a command that can be executed in the REPL.
+/// </summary>
+public interface ICommand
+{
+    /// <summary>
+    /// Gets the primary name of the command (e.g., "session").
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets a brief description of what the command does.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Gets the usage pattern for the command (e.g., "session <start|list|leave|resume|delete> [args]").
+    /// </summary>
+    string Usage { get; }
+
+    /// <summary>
+    /// Executes the command with the given arguments.
+    /// </summary>
+    /// <param name="args">The arguments passed to the command (excluding the command name itself).</param>
+    /// <param name="context">The current command context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of the command execution.</returns>
+    Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default);
+}

--- a/src/NimbusStation.Core/Commands/IProviderCommand.cs
+++ b/src/NimbusStation.Core/Commands/IProviderCommand.cs
@@ -1,0 +1,13 @@
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// Represents a command that is specific to a cloud provider.
+/// Provider commands are prefixed with the provider name (e.g., "azure cosmos query").
+/// </summary>
+public interface IProviderCommand : ICommand
+{
+    /// <summary>
+    /// Gets the provider identifier this command belongs to (e.g., "azure", "aws", "gcp").
+    /// </summary>
+    string ProviderId { get; }
+}

--- a/src/NimbusStation.Core/Session/ISessionService.cs
+++ b/src/NimbusStation.Core/Session/ISessionService.cs
@@ -1,0 +1,79 @@
+namespace NimbusStation.Core.Session;
+
+/// <summary>
+/// Service for managing session lifecycle operations.
+/// </summary>
+public interface ISessionService
+{
+    /// <summary>
+    /// Starts a session with the specified name. Creates a new session if it doesn't exist,
+    /// or resumes the existing session if it does.
+    /// </summary>
+    /// <param name="sessionName">The name for the session (e.g., ticket ID).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The session (newly created or resumed).</returns>
+    /// <exception cref="InvalidSessionNameException">Thrown if the session name is invalid.</exception>
+    Task<Session> StartSessionAsync(string sessionName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all existing sessions.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A read-only list of all sessions.</returns>
+    Task<IReadOnlyList<Session>> ListSessionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resumes an existing session by name.
+    /// </summary>
+    /// <param name="sessionName">The name of the session to resume.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resumed session with updated LastAccessedAt.</returns>
+    /// <exception cref="SessionNotFoundException">Thrown if the session does not exist.</exception>
+    Task<Session> ResumeSessionAsync(string sessionName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a session and its associated directory.
+    /// </summary>
+    /// <param name="sessionName">The name of the session to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="SessionNotFoundException">Thrown if the session does not exist.</exception>
+    Task DeleteSessionAsync(string sessionName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the active context for a session.
+    /// </summary>
+    /// <param name="sessionName">The name of the session.</param>
+    /// <param name="context">The new active context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated session.</returns>
+    /// <exception cref="SessionNotFoundException">Thrown if the session does not exist.</exception>
+    Task<Session> UpdateSessionContextAsync(string sessionName, SessionContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a session with the specified name exists.
+    /// </summary>
+    /// <param name="sessionName">The name of the session.</param>
+    /// <returns>True if the session exists, false otherwise.</returns>
+    bool SessionExists(string sessionName);
+
+    /// <summary>
+    /// Gets the root directory path for a session.
+    /// </summary>
+    /// <param name="sessionName">The name of the session.</param>
+    /// <returns>The full path to the session directory.</returns>
+    string GetSessionDirectory(string sessionName);
+
+    /// <summary>
+    /// Gets the downloads directory path for a session.
+    /// </summary>
+    /// <param name="sessionName">The name of the session.</param>
+    /// <returns>The full path to the downloads directory.</returns>
+    string GetDownloadsDirectory(string sessionName);
+
+    /// <summary>
+    /// Gets the queries directory path for a session.
+    /// </summary>
+    /// <param name="sessionName">The name of the session.</param>
+    /// <returns>The full path to the queries directory.</returns>
+    string GetQueriesDirectory(string sessionName);
+}

--- a/src/NimbusStation.Core/Session/Session.cs
+++ b/src/NimbusStation.Core/Session/Session.cs
@@ -1,0 +1,40 @@
+namespace NimbusStation.Core.Session;
+
+/// <summary>
+/// Represents a Nimbus Station session tied to a ticket ID.
+/// Sessions persist state to ~/.nimbus/sessions/{TicketId}/.
+/// </summary>
+/// <param name="TicketId">The unique identifier for this session (e.g., "SUP-123").</param>
+/// <param name="CreatedAt">When the session was first created.</param>
+/// <param name="LastAccessedAt">When the session was last accessed or resumed.</param>
+/// <param name="ActiveContext">The currently active context within the session.</param>
+public sealed record Session(
+    string TicketId,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset LastAccessedAt,
+    SessionContext? ActiveContext)
+{
+    /// <summary>
+    /// Creates a new session with the current timestamp.
+    /// </summary>
+    /// <param name="ticketId">The ticket ID for the session.</param>
+    /// <returns>A new session instance.</returns>
+    public static Session Create(string ticketId)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new Session(ticketId, now, now, null);
+    }
+
+    /// <summary>
+    /// Creates a new session instance with an updated LastAccessedAt timestamp.
+    /// </summary>
+    /// <returns>A new session with the current UTC time as LastAccessedAt.</returns>
+    public Session Touch() => this with { LastAccessedAt = DateTimeOffset.UtcNow };
+
+    /// <summary>
+    /// Creates a new session instance with an updated active context.
+    /// </summary>
+    /// <param name="context">The new active context.</param>
+    /// <returns>A new session with the updated context.</returns>
+    public Session WithContext(SessionContext? context) => this with { ActiveContext = context };
+}

--- a/src/NimbusStation.Core/Session/SessionContext.cs
+++ b/src/NimbusStation.Core/Session/SessionContext.cs
@@ -1,0 +1,17 @@
+namespace NimbusStation.Core.Session;
+
+/// <summary>
+/// Represents the active context within a session.
+/// Tracks which resource aliases are currently selected for operations.
+/// </summary>
+/// <param name="ActiveCosmosAlias">The currently selected CosmosDB alias, if any.</param>
+/// <param name="ActiveBlobAlias">The currently selected Blob storage alias, if any.</param>
+public sealed record SessionContext(
+    string? ActiveCosmosAlias,
+    string? ActiveBlobAlias)
+{
+    /// <summary>
+    /// Gets an empty context with no active aliases.
+    /// </summary>
+    public static SessionContext Empty => new(null, null);
+}

--- a/src/NimbusStation.Core/Session/SessionExceptions.cs
+++ b/src/NimbusStation.Core/Session/SessionExceptions.cs
@@ -1,0 +1,65 @@
+namespace NimbusStation.Core.Session;
+
+/// <summary>
+/// Exception thrown when attempting to create a session that already exists.
+/// </summary>
+public sealed class SessionAlreadyExistsException : Exception
+{
+    /// <summary>
+    /// Gets the name of the session that already exists.
+    /// </summary>
+    public string SessionName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionAlreadyExistsException"/> class.
+    /// </summary>
+    /// <param name="sessionName">The name of the session that already exists.</param>
+    public SessionAlreadyExistsException(string sessionName)
+        : base($"Session '{sessionName}' already exists. Use 'session resume {sessionName}' to continue.")
+    {
+        SessionName = sessionName;
+    }
+}
+
+/// <summary>
+/// Exception thrown when attempting to access a session that does not exist.
+/// </summary>
+public sealed class SessionNotFoundException : Exception
+{
+    /// <summary>
+    /// Gets the name of the session that was not found.
+    /// </summary>
+    public string SessionName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionNotFoundException"/> class.
+    /// </summary>
+    /// <param name="sessionName">The name of the session that was not found.</param>
+    public SessionNotFoundException(string sessionName)
+        : base($"Session '{sessionName}' not found. Use 'session list' to see available sessions.")
+    {
+        SessionName = sessionName;
+    }
+}
+
+/// <summary>
+/// Exception thrown when a session name is invalid.
+/// </summary>
+public sealed class InvalidSessionNameException : Exception
+{
+    /// <summary>
+    /// Gets the invalid session name.
+    /// </summary>
+    public string SessionName { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidSessionNameException"/> class.
+    /// </summary>
+    /// <param name="sessionName">The invalid session name.</param>
+    /// <param name="reason">The reason the name is invalid.</param>
+    public InvalidSessionNameException(string sessionName, string reason)
+        : base($"Invalid session name '{sessionName}': {reason}")
+    {
+        SessionName = sessionName;
+    }
+}

--- a/src/NimbusStation.Core/Session/SessionNameValidator.cs
+++ b/src/NimbusStation.Core/Session/SessionNameValidator.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+
+namespace NimbusStation.Core.Session;
+
+/// <summary>
+/// Validates session names to ensure they are valid directory names across all operating systems.
+/// </summary>
+public static partial class SessionNameValidator
+{
+    /// <summary>
+    /// Maximum allowed length for a session name.
+    /// </summary>
+    public const int MaxLength = 255;
+
+    /// <summary>
+    /// Characters that are not allowed in session names.
+    /// </summary>
+    private static readonly char[] InvalidChars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+
+    /// <summary>
+    /// Reserved names on Windows that cannot be used as directory names.
+    /// </summary>
+    private static readonly HashSet<string> ReservedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+    };
+
+    /// <summary>
+    /// Validates a session name and returns whether it is valid.
+    /// </summary>
+    /// <param name="name">The session name to validate.</param>
+    /// <param name="errorMessage">The error message if validation fails, null otherwise.</param>
+    /// <returns>True if the name is valid, false otherwise.</returns>
+    public static bool IsValid(string? name, out string? errorMessage)
+    {
+        // Check for null or empty
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            errorMessage = "Session name cannot be empty.";
+            return false;
+        }
+
+        // Check length
+        if (name.Length > MaxLength)
+        {
+            errorMessage = $"Session name cannot exceed {MaxLength} characters.";
+            return false;
+        }
+
+        // Check for leading/trailing whitespace
+        if (name != name.Trim())
+        {
+            errorMessage = "Session name cannot have leading or trailing whitespace.";
+            return false;
+        }
+
+        // Check for leading/trailing dots
+        if (name.StartsWith('.') || name.EndsWith('.'))
+        {
+            errorMessage = "Session name cannot start or end with a dot.";
+            return false;
+        }
+
+        // Check for invalid characters
+        var invalidCharIndex = name.IndexOfAny(InvalidChars);
+        if (invalidCharIndex >= 0)
+        {
+            errorMessage = $"Session name cannot contain '{name[invalidCharIndex]}' character.";
+            return false;
+        }
+
+        // Check for control characters
+        if (name.Any(char.IsControl))
+        {
+            errorMessage = "Session name cannot contain control characters.";
+            return false;
+        }
+
+        // Check for reserved Windows names (with or without extension)
+        var nameWithoutExtension = GetNameWithoutExtension(name);
+        if (ReservedNames.Contains(nameWithoutExtension))
+        {
+            errorMessage = $"Session name '{nameWithoutExtension}' is reserved on Windows.";
+            return false;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Validates a session name and throws an exception if invalid.
+    /// </summary>
+    /// <param name="name">The session name to validate.</param>
+    /// <exception cref="InvalidSessionNameException">Thrown if the name is invalid.</exception>
+    public static void Validate(string? name)
+    {
+        if (!IsValid(name, out var errorMessage))
+        {
+            throw new InvalidSessionNameException(name ?? string.Empty, errorMessage!);
+        }
+    }
+
+    /// <summary>
+    /// Extracts the name without extension for reserved name checking.
+    /// </summary>
+    private static string GetNameWithoutExtension(string name)
+    {
+        var dotIndex = name.IndexOf('.');
+        return dotIndex >= 0 ? name[..dotIndex] : name;
+    }
+}

--- a/src/NimbusStation.Infrastructure/Sessions/SessionSerializer.cs
+++ b/src/NimbusStation.Infrastructure/Sessions/SessionSerializer.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NimbusStation.Core.Session;
+
+namespace NimbusStation.Infrastructure.Sessions;
+
+/// <summary>
+/// Handles serialization and deserialization of session data to/from JSON files.
+/// </summary>
+public sealed class SessionSerializer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Serializes a session to JSON and writes it to a file.
+    /// </summary>
+    /// <param name="session">The session to serialize.</param>
+    /// <param name="filePath">The path to write the JSON file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task WriteSessionAsync(Session session, string filePath, CancellationToken cancellationToken = default)
+    {
+        var dto = SessionDto.FromSession(session);
+        var json = JsonSerializer.Serialize(dto, JsonOptions);
+        await File.WriteAllTextAsync(filePath, json, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a session from a JSON file.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The deserialized session.</returns>
+    /// <exception cref="FileNotFoundException">Thrown if the file does not exist.</exception>
+    /// <exception cref="JsonException">Thrown if the JSON is invalid.</exception>
+    public async Task<Session> ReadSessionAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var json = await File.ReadAllTextAsync(filePath, cancellationToken);
+        var dto = JsonSerializer.Deserialize<SessionDto>(json, JsonOptions)
+            ?? throw new JsonException("Failed to deserialize session: result was null");
+
+        return dto.ToSession();
+    }
+
+    /// <summary>
+    /// DTO for JSON serialization of Session.
+    /// </summary>
+    private sealed class SessionDto
+    {
+        public required string TicketId { get; set; }
+        public required DateTimeOffset CreatedAt { get; set; }
+        public required DateTimeOffset LastAccessedAt { get; set; }
+        public SessionContextDto? ActiveContext { get; set; }
+
+        public static SessionDto FromSession(Session session) => new()
+        {
+            TicketId = session.TicketId,
+            CreatedAt = session.CreatedAt,
+            LastAccessedAt = session.LastAccessedAt,
+            ActiveContext = session.ActiveContext is not null
+                ? SessionContextDto.FromContext(session.ActiveContext)
+                : null
+        };
+
+        public Session ToSession() => new(
+            TicketId,
+            CreatedAt,
+            LastAccessedAt,
+            ActiveContext?.ToContext());
+    }
+
+    /// <summary>
+    /// DTO for JSON serialization of SessionContext.
+    /// </summary>
+    private sealed class SessionContextDto
+    {
+        public string? ActiveCosmosAlias { get; set; }
+        public string? ActiveBlobAlias { get; set; }
+
+        public static SessionContextDto FromContext(SessionContext context) => new()
+        {
+            ActiveCosmosAlias = context.ActiveCosmosAlias,
+            ActiveBlobAlias = context.ActiveBlobAlias
+        };
+
+        public SessionContext ToContext() => new(ActiveCosmosAlias, ActiveBlobAlias);
+    }
+}

--- a/src/NimbusStation.Infrastructure/Sessions/SessionService.cs
+++ b/src/NimbusStation.Infrastructure/Sessions/SessionService.cs
@@ -1,0 +1,206 @@
+using Microsoft.Extensions.Logging;
+using NimbusStation.Core.Session;
+
+namespace NimbusStation.Infrastructure.Sessions;
+
+/// <summary>
+/// File-based implementation of the session service.
+/// Manages sessions in ~/.nimbus/sessions/{session-name}/.
+/// </summary>
+public sealed class SessionService : ISessionService
+{
+    private const string SessionFileName = "session.json";
+    private const string DownloadsDirName = "downloads";
+    private const string QueriesDirName = "queries";
+
+    private readonly ILogger<SessionService> _logger;
+    private readonly SessionSerializer _serializer;
+    private readonly string _sessionsRoot;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionService"/> class.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    public SessionService(ILogger<SessionService> logger)
+        : this(logger, GetDefaultSessionsRoot())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionService"/> class with a custom sessions root.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="sessionsRoot">The root directory for sessions.</param>
+    public SessionService(ILogger<SessionService> logger, string sessionsRoot)
+    {
+        _logger = logger;
+        _serializer = new SessionSerializer();
+        _sessionsRoot = sessionsRoot;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This method is forgiving: if the session already exists, it will resume it instead of failing.
+    /// This allows users to use "session start" without needing to remember if the session exists.
+    /// </remarks>
+    public async Task<Session> StartSessionAsync(string sessionName, CancellationToken cancellationToken = default)
+    {
+        SessionNameValidator.Validate(sessionName);
+
+        var sessionDir = GetSessionDirectory(sessionName);
+        var sessionFile = Path.Combine(sessionDir, SessionFileName);
+
+        // If session already exists, resume it instead of failing
+        if (Directory.Exists(sessionDir) && File.Exists(sessionFile))
+        {
+            _logger.LogInformation("Session '{SessionName}' already exists, resuming", sessionName);
+            return await ResumeSessionAsync(sessionName, cancellationToken);
+        }
+
+        // Create session directory structure
+        Directory.CreateDirectory(sessionDir);
+        Directory.CreateDirectory(GetDownloadsDirectory(sessionName));
+        Directory.CreateDirectory(GetQueriesDirectory(sessionName));
+
+        // Create and persist session
+        var session = Session.Create(sessionName);
+        await _serializer.WriteSessionAsync(session, sessionFile, cancellationToken);
+
+        _logger.LogInformation("Created session '{SessionName}' at {SessionDir}", sessionName, sessionDir);
+
+        return session;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Session>> ListSessionsAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureSessionsRootExists();
+
+        var sessions = new List<Session>();
+
+        if (!Directory.Exists(_sessionsRoot))
+        {
+            return sessions;
+        }
+
+        foreach (var sessionDir in Directory.GetDirectories(_sessionsRoot))
+        {
+            var sessionFile = Path.Combine(sessionDir, SessionFileName);
+            if (!File.Exists(sessionFile))
+            {
+                _logger.LogWarning("Session directory {SessionDir} has no session.json, skipping", sessionDir);
+                continue;
+            }
+
+            try
+            {
+                var session = await _serializer.ReadSessionAsync(sessionFile, cancellationToken);
+                sessions.Add(session);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read session from {SessionFile}, skipping", sessionFile);
+            }
+        }
+
+        return sessions.OrderByDescending(s => s.LastAccessedAt).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<Session> ResumeSessionAsync(string sessionName, CancellationToken cancellationToken = default)
+    {
+        var sessionDir = GetSessionDirectory(sessionName);
+        var sessionFile = Path.Combine(sessionDir, SessionFileName);
+
+        if (!Directory.Exists(sessionDir) || !File.Exists(sessionFile))
+        {
+            throw new SessionNotFoundException(sessionName);
+        }
+
+        // Read, touch, and persist
+        var session = await _serializer.ReadSessionAsync(sessionFile, cancellationToken);
+        session = session.Touch();
+        await _serializer.WriteSessionAsync(session, sessionFile, cancellationToken);
+
+        _logger.LogInformation("Resumed session '{SessionName}'", sessionName);
+
+        return session;
+    }
+
+    /// <inheritdoc/>
+    public Task DeleteSessionAsync(string sessionName, CancellationToken cancellationToken = default)
+    {
+        var sessionDir = GetSessionDirectory(sessionName);
+
+        if (!Directory.Exists(sessionDir))
+        {
+            throw new SessionNotFoundException(sessionName);
+        }
+
+        Directory.Delete(sessionDir, recursive: true);
+        _logger.LogInformation("Deleted session '{SessionName}'", sessionName);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Session> UpdateSessionContextAsync(string sessionName, SessionContext context, CancellationToken cancellationToken = default)
+    {
+        var sessionDir = GetSessionDirectory(sessionName);
+        var sessionFile = Path.Combine(sessionDir, SessionFileName);
+
+        if (!Directory.Exists(sessionDir) || !File.Exists(sessionFile))
+        {
+            throw new SessionNotFoundException(sessionName);
+        }
+
+        var session = await _serializer.ReadSessionAsync(sessionFile, cancellationToken);
+        session = session.WithContext(context).Touch();
+        await _serializer.WriteSessionAsync(session, sessionFile, cancellationToken);
+
+        _logger.LogDebug("Updated context for session '{SessionName}'", sessionName);
+
+        return session;
+    }
+
+    /// <inheritdoc/>
+    public bool SessionExists(string sessionName)
+    {
+        var sessionDir = GetSessionDirectory(sessionName);
+        var sessionFile = Path.Combine(sessionDir, SessionFileName);
+        return Directory.Exists(sessionDir) && File.Exists(sessionFile);
+    }
+
+    /// <inheritdoc/>
+    public string GetSessionDirectory(string sessionName)
+    {
+        return Path.Combine(_sessionsRoot, sessionName);
+    }
+
+    /// <inheritdoc/>
+    public string GetDownloadsDirectory(string sessionName)
+    {
+        return Path.Combine(GetSessionDirectory(sessionName), DownloadsDirName);
+    }
+
+    /// <inheritdoc/>
+    public string GetQueriesDirectory(string sessionName)
+    {
+        return Path.Combine(GetSessionDirectory(sessionName), QueriesDirName);
+    }
+
+    private static string GetDefaultSessionsRoot()
+    {
+        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(homeDir, ".nimbus", "sessions");
+    }
+
+    private void EnsureSessionsRootExists()
+    {
+        if (!Directory.Exists(_sessionsRoot))
+        {
+            Directory.CreateDirectory(_sessionsRoot);
+            _logger.LogDebug("Created sessions root directory at {SessionsRoot}", _sessionsRoot);
+        }
+    }
+}

--- a/src/NimbusStation.Tests/Core/Session/SessionNameValidatorTests.cs
+++ b/src/NimbusStation.Tests/Core/Session/SessionNameValidatorTests.cs
@@ -1,0 +1,136 @@
+using NimbusStation.Core.Session;
+
+namespace NimbusStation.Tests.Core.Session;
+
+public sealed class SessionNameValidatorTests
+{
+    [Theory]
+    [InlineData("SUP-123")]
+    [InlineData("my-ticket")]
+    [InlineData("2025-01-15")]
+    [InlineData("ticket_with_underscore")]
+    [InlineData("ALLCAPS")]
+    [InlineData("123456")]
+    [InlineData("a")]
+    public void IsValid_ValidNames_ReturnsTrue(string name)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.True(result);
+        Assert.Null(errorMessage);
+    }
+
+    [Theory]
+    [InlineData(null, "empty")]
+    [InlineData("", "empty")]
+    [InlineData("   ", "empty")]
+    public void IsValid_EmptyOrNull_ReturnsFalse(string? name, string expectedContains)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.NotNull(errorMessage);
+        Assert.Contains(expectedContains, errorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(" leading")]
+    [InlineData("trailing ")]
+    [InlineData(" both ")]
+    public void IsValid_LeadingOrTrailingWhitespace_ReturnsFalse(string name)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.Contains("whitespace", errorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(".hidden")]
+    [InlineData("trailing.")]
+    public void IsValid_LeadingOrTrailingDot_ReturnsFalse(string name)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.Contains("dot", errorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("path/separator")]
+    [InlineData("path\\separator")]
+    [InlineData("has<angle")]
+    [InlineData("has>angle")]
+    [InlineData("has:colon")]
+    [InlineData("has\"quote")]
+    [InlineData("has|pipe")]
+    [InlineData("has?question")]
+    [InlineData("has*star")]
+    public void IsValid_InvalidCharacters_ReturnsFalse(string name)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.Contains("cannot contain", errorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("con")]
+    [InlineData("PRN")]
+    [InlineData("AUX")]
+    [InlineData("NUL")]
+    [InlineData("COM1")]
+    [InlineData("COM9")]
+    [InlineData("LPT1")]
+    [InlineData("LPT9")]
+    [InlineData("CON.txt")]
+    [InlineData("nul.log")]
+    public void IsValid_WindowsReservedNames_ReturnsFalse(string name)
+    {
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.Contains("reserved", errorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsValid_TooLong_ReturnsFalse()
+    {
+        var name = new string('a', 256);
+
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.False(result);
+        Assert.Contains("255", errorMessage!);
+    }
+
+    [Fact]
+    public void IsValid_MaxLength_ReturnsTrue()
+    {
+        var name = new string('a', 255);
+
+        var result = SessionNameValidator.IsValid(name, out var errorMessage);
+
+        Assert.True(result);
+        Assert.Null(errorMessage);
+    }
+
+    [Fact]
+    public void Validate_ValidName_DoesNotThrow()
+    {
+        var exception = Record.Exception(() => SessionNameValidator.Validate("SUP-123"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_InvalidName_ThrowsInvalidSessionNameException()
+    {
+        var exception = Assert.Throws<InvalidSessionNameException>(
+            () => SessionNameValidator.Validate("invalid/name"));
+
+        Assert.Equal("invalid/name", exception.SessionName);
+        Assert.Contains("/", exception.Message);
+    }
+}

--- a/src/NimbusStation.Tests/Infrastructure/Sessions/SessionSerializerTests.cs
+++ b/src/NimbusStation.Tests/Infrastructure/Sessions/SessionSerializerTests.cs
@@ -1,0 +1,104 @@
+using NimbusStation.Core.Session;
+using NimbusStation.Infrastructure.Sessions;
+
+namespace NimbusStation.Tests.Infrastructure.Sessions;
+
+public sealed class SessionSerializerTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly SessionSerializer _serializer;
+
+    public SessionSerializerTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"nimbus-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+        _serializer = new SessionSerializer();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, recursive: true);
+    }
+
+    private string GetFilePath(string fileName = "session.json") =>
+        Path.Combine(_tempDirectory, fileName);
+
+    [Fact]
+    public async Task WriteAndRead_RoundTrip_PreservesData()
+    {
+        var session = new Session(
+            "SUP-123",
+            new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero),
+            new DateTimeOffset(2025, 1, 15, 14, 45, 0, TimeSpan.Zero),
+            new SessionContext("prod-cosmos", "prod-blob"));
+
+        var filePath = GetFilePath();
+
+        await _serializer.WriteSessionAsync(session, filePath);
+        var result = await _serializer.ReadSessionAsync(filePath);
+
+        Assert.Equal(session.TicketId, result.TicketId);
+        Assert.Equal(session.CreatedAt, result.CreatedAt);
+        Assert.Equal(session.LastAccessedAt, result.LastAccessedAt);
+        Assert.NotNull(result.ActiveContext);
+        Assert.Equal(session.ActiveContext!.ActiveCosmosAlias, result.ActiveContext.ActiveCosmosAlias);
+        Assert.Equal(session.ActiveContext.ActiveBlobAlias, result.ActiveContext.ActiveBlobAlias);
+    }
+
+    [Fact]
+    public async Task WriteAndRead_NullContext_PreservesNull()
+    {
+        var session = Session.Create("SUP-456");
+        var filePath = GetFilePath();
+
+        await _serializer.WriteSessionAsync(session, filePath);
+        var result = await _serializer.ReadSessionAsync(filePath);
+
+        Assert.Equal(session.TicketId, result.TicketId);
+        Assert.Null(result.ActiveContext);
+    }
+
+    [Fact]
+    public async Task WriteAndRead_PartialContext_PreservesPartial()
+    {
+        var session = new Session(
+            "SUP-789",
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            new SessionContext("only-cosmos", null));
+
+        var filePath = GetFilePath();
+
+        await _serializer.WriteSessionAsync(session, filePath);
+        var result = await _serializer.ReadSessionAsync(filePath);
+
+        Assert.NotNull(result.ActiveContext);
+        Assert.Equal("only-cosmos", result.ActiveContext.ActiveCosmosAlias);
+        Assert.Null(result.ActiveContext.ActiveBlobAlias);
+    }
+
+    [Fact]
+    public async Task ReadSessionAsync_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        var filePath = GetFilePath("nonexistent.json");
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => _serializer.ReadSessionAsync(filePath));
+    }
+
+    [Fact]
+    public async Task WriteSessionAsync_CreatesValidJson()
+    {
+        var session = Session.Create("TEST-001");
+        var filePath = GetFilePath();
+
+        await _serializer.WriteSessionAsync(session, filePath);
+
+        var json = await File.ReadAllTextAsync(filePath);
+        Assert.Contains("\"ticketId\"", json);
+        Assert.Contains("\"createdAt\"", json);
+        Assert.Contains("\"lastAccessedAt\"", json);
+        Assert.Contains("TEST-001", json);
+    }
+}

--- a/src/NimbusStation.Tests/Infrastructure/Sessions/SessionServiceTests.cs
+++ b/src/NimbusStation.Tests/Infrastructure/Sessions/SessionServiceTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.Logging;
+using NimbusStation.Core.Session;
+using NimbusStation.Infrastructure.Sessions;
+
+namespace NimbusStation.Tests.Infrastructure.Sessions;
+
+public sealed class SessionServiceTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly ILogger<SessionService> _logger;
+    private readonly SessionService _service;
+
+    public SessionServiceTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"nimbus-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+        _logger = new LoggerFactory().CreateLogger<SessionService>();
+        _service = new SessionService(_logger, _tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, recursive: true);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_NewSession_CreatesDirectoryStructure()
+    {
+        var session = await _service.StartSessionAsync("SUP-123");
+
+        Assert.Equal("SUP-123", session.TicketId);
+        Assert.True(Directory.Exists(_service.GetSessionDirectory("SUP-123")));
+        Assert.True(Directory.Exists(_service.GetDownloadsDirectory("SUP-123")));
+        Assert.True(Directory.Exists(_service.GetQueriesDirectory("SUP-123")));
+        Assert.True(File.Exists(Path.Combine(_service.GetSessionDirectory("SUP-123"), "session.json")));
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_ExistingSession_ResumesInstead()
+    {
+        var original = await _service.StartSessionAsync("SUP-123");
+        await Task.Delay(10); // Ensure time passes
+
+        var resumed = await _service.StartSessionAsync("SUP-123");
+
+        Assert.Equal(original.TicketId, resumed.TicketId);
+        Assert.Equal(original.CreatedAt, resumed.CreatedAt);
+        Assert.True(resumed.LastAccessedAt > original.LastAccessedAt);
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_InvalidName_ThrowsInvalidSessionNameException()
+    {
+        await Assert.ThrowsAsync<InvalidSessionNameException>(
+            () => _service.StartSessionAsync("invalid/name"));
+    }
+
+    [Fact]
+    public async Task ListSessionsAsync_NoSessions_ReturnsEmptyList()
+    {
+        var sessions = await _service.ListSessionsAsync();
+
+        Assert.Empty(sessions);
+    }
+
+    [Fact]
+    public async Task ListSessionsAsync_MultipleSessions_ReturnsAllOrderedByLastAccessed()
+    {
+        await _service.StartSessionAsync("SUP-001");
+        await Task.Delay(10);
+        await _service.StartSessionAsync("SUP-002");
+        await Task.Delay(10);
+        await _service.StartSessionAsync("SUP-003");
+
+        var sessions = await _service.ListSessionsAsync();
+
+        Assert.Equal(3, sessions.Count);
+        Assert.Equal("SUP-003", sessions[0].TicketId); // Most recent first
+        Assert.Equal("SUP-002", sessions[1].TicketId);
+        Assert.Equal("SUP-001", sessions[2].TicketId);
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_ExistingSession_UpdatesLastAccessedAt()
+    {
+        var original = await _service.StartSessionAsync("SUP-123");
+        await Task.Delay(10);
+
+        var resumed = await _service.ResumeSessionAsync("SUP-123");
+
+        Assert.Equal(original.CreatedAt, resumed.CreatedAt);
+        Assert.True(resumed.LastAccessedAt > original.LastAccessedAt);
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_NonExistent_ThrowsSessionNotFoundException()
+    {
+        await Assert.ThrowsAsync<SessionNotFoundException>(
+            () => _service.ResumeSessionAsync("NONEXISTENT-999"));
+    }
+
+    [Fact]
+    public async Task DeleteSessionAsync_ExistingSession_RemovesDirectory()
+    {
+        await _service.StartSessionAsync("SUP-123");
+        Assert.True(_service.SessionExists("SUP-123"));
+
+        await _service.DeleteSessionAsync("SUP-123");
+
+        Assert.False(_service.SessionExists("SUP-123"));
+        Assert.False(Directory.Exists(_service.GetSessionDirectory("SUP-123")));
+    }
+
+    [Fact]
+    public async Task DeleteSessionAsync_NonExistent_ThrowsSessionNotFoundException()
+    {
+        await Assert.ThrowsAsync<SessionNotFoundException>(
+            () => _service.DeleteSessionAsync("NONEXISTENT-999"));
+    }
+
+    [Fact]
+    public async Task UpdateSessionContextAsync_ExistingSession_UpdatesContext()
+    {
+        await _service.StartSessionAsync("SUP-123");
+        var context = new SessionContext("my-cosmos", "my-blob");
+
+        var updated = await _service.UpdateSessionContextAsync("SUP-123", context);
+
+        Assert.NotNull(updated.ActiveContext);
+        Assert.Equal("my-cosmos", updated.ActiveContext.ActiveCosmosAlias);
+        Assert.Equal("my-blob", updated.ActiveContext.ActiveBlobAlias);
+    }
+
+    [Fact]
+    public async Task UpdateSessionContextAsync_NonExistent_ThrowsSessionNotFoundException()
+    {
+        var context = new SessionContext("my-cosmos", null);
+
+        await Assert.ThrowsAsync<SessionNotFoundException>(
+            () => _service.UpdateSessionContextAsync("NONEXISTENT-999", context));
+    }
+
+    [Fact]
+    public async Task SessionExists_ExistingSession_ReturnsTrue()
+    {
+        await _service.StartSessionAsync("SUP-123");
+
+        Assert.True(_service.SessionExists("SUP-123"));
+    }
+
+    [Fact]
+    public void SessionExists_NonExistent_ReturnsFalse()
+    {
+        Assert.False(_service.SessionExists("NONEXISTENT-999"));
+    }
+
+    [Fact]
+    public void GetSessionDirectory_ReturnsCorrectPath()
+    {
+        var path = _service.GetSessionDirectory("SUP-123");
+
+        Assert.Equal(Path.Combine(_tempDirectory, "SUP-123"), path);
+    }
+
+    [Fact]
+    public void GetDownloadsDirectory_ReturnsCorrectPath()
+    {
+        var path = _service.GetDownloadsDirectory("SUP-123");
+
+        Assert.Equal(Path.Combine(_tempDirectory, "SUP-123", "downloads"), path);
+    }
+
+    [Fact]
+    public void GetQueriesDirectory_ReturnsCorrectPath()
+    {
+        var path = _service.GetQueriesDirectory("SUP-123");
+
+        Assert.Equal(Path.Combine(_tempDirectory, "SUP-123", "queries"), path);
+    }
+}


### PR DESCRIPTION
Add session management system that allows users to create, list, resume, and delete investigation sessions tied to ticket IDs. Sessions persist state to ~/.nimbus/sessions/{session-name}/.

Core features:
- Session commands: start, list, leave, resume, delete, status
- Forgiving 'session start' that creates or resumes as needed
- Cross-platform session name validation (safe directory names)
- Session-aware REPL prompt showing active session
- Command infrastructure with ICommand/IProviderCommand interfaces

Implementation:
- NimbusStation.Core: Session model, ISessionService, command interfaces
- NimbusStation.Infrastructure: File-based SessionService, JSON serializer
- NimbusStation.Cli: CommandRegistry, SessionCommand, ReplLoop, InputParser

Includes 38 new tests for session validation, serialization, and service.

Closes #3