### PR TITLE
feat: Add configurable UI theming with 24 preset themes

### DIFF
--- a/src/NimbusStation.Cli/Commands/BlobCommand.cs
+++ b/src/NimbusStation.Cli/Commands/BlobCommand.cs
@@ -89,8 +89,9 @@ public sealed class BlobCommand : ICommand
                     container.LastModified.ToString("yyyy-MM-dd HH:mm"));
             }
 
+            var theme = _configurationService.GetTheme();
             AnsiConsole.Write(table);
-            context.Output.WriteErrorLine($"[dim]{result.Containers.Count} container(s) in {aliasConfig.Account}[/]");
+            context.Output.WriteErrorLine($"[{theme.DimColor}]{result.Containers.Count} container(s) in {aliasConfig.Account}[/]");
 
             return CommandResult.Ok(data: result);
         }
@@ -129,8 +130,9 @@ public sealed class BlobCommand : ICommand
                     blob.LastModified.ToString("yyyy-MM-dd HH:mm"));
             }
 
+            var theme = _configurationService.GetTheme();
             AnsiConsole.Write(table);
-            context.Output.WriteErrorLine($"[dim]{result.Blobs.Count} blob(s) in {aliasConfig.Container}[/]");
+            context.Output.WriteErrorLine($"[{theme.DimColor}]{result.Blobs.Count} blob(s) in {aliasConfig.Container}[/]");
 
             return CommandResult.Ok(data: result);
         }
@@ -160,10 +162,11 @@ public sealed class BlobCommand : ICommand
             var result = await _blobService.GetBlobContentAsync(activeAlias, blobName, cancellationToken);
 
             // Check for binary content and warn if not piped
+            var theme = _configurationService.GetTheme();
             if (result.IsBinary && !Console.IsOutputRedirected)
             {
-                context.Output.WriteErrorLine($"[yellow]Warning: This appears to be a binary file ({result.ContentType}).[/]");
-                context.Output.WriteErrorLine("[yellow]Use 'blob download' to save to a file, or pipe the output.[/]");
+                context.Output.WriteErrorLine($"[{theme.WarningColor}]Warning: This appears to be a binary file ({result.ContentType}).[/]");
+                context.Output.WriteErrorLine($"[{theme.WarningColor}]Use 'blob download' to save to a file, or pipe the output.[/]");
 
                 if (!AnsiConsole.Confirm("Continue anyway?", defaultValue: false))
                     return CommandResult.Ok();
@@ -198,8 +201,9 @@ public sealed class BlobCommand : ICommand
 
         try
         {
+            var theme = _configurationService.GetTheme();
             var downloadedPath = await _blobService.DownloadBlobAsync(activeAlias, blobName, downloadsDir, cancellationToken);
-            context.Output.WriteLine($"[green]Downloaded to:[/] {downloadedPath}");
+            context.Output.WriteLine($"[{theme.SuccessColor}]Downloaded to:[/] {downloadedPath}");
 
             return CommandResult.Ok(data: downloadedPath);
         }

--- a/src/NimbusStation.Cli/Commands/InfoCommand.cs
+++ b/src/NimbusStation.Cli/Commands/InfoCommand.cs
@@ -1,3 +1,4 @@
+using NimbusStation.Cli.Output;
 using NimbusStation.Core.Commands;
 using NimbusStation.Infrastructure.Configuration;
 using Spectre.Console;
@@ -35,6 +36,8 @@ public sealed class InfoCommand : ICommand
     /// <inheritdoc/>
     public Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default)
     {
+        var theme = _configurationService.GetTheme();
+
         if (context.CurrentSession is null)
             return Task.FromResult(CommandResult.Error("No active session. Use 'session start <ticket>' first."));
 
@@ -44,13 +47,13 @@ public sealed class InfoCommand : ICommand
         if (activeContext is null ||
             (activeContext.ActiveCosmosAlias is null && activeContext.ActiveBlobAlias is null))
         {
-            context.Output.WriteLine("[dim]No active context. Use 'use cosmos <alias>' or 'use blob <alias>' to set one.[/]");
+            context.Output.WriteLine($"[{theme.DimColor}]No active context. Use 'use cosmos <alias>' or 'use blob <alias>' to set one.[/]");
             return Task.FromResult(CommandResult.Ok());
         }
 
         var table = new Table()
             .Border(TableBorder.Rounded)
-            .BorderColor(Color.Grey);
+            .BorderColor(SpectreColorHelper.ParseColorOrDefault(theme.TableBorderColor, Color.Grey));
 
         table.AddColumn(new TableColumn("[bold]Property[/]").LeftAligned());
         table.AddColumn(new TableColumn("[bold]Value[/]").LeftAligned());
@@ -60,8 +63,8 @@ public sealed class InfoCommand : ICommand
         {
             var cosmosConfig = _configurationService.GetCosmosAlias(cosmosAlias);
 
-            table.AddRow("[orange1 bold]CosmosDB[/]", "");
-            table.AddRow("  Alias", $"[cyan]{cosmosAlias}[/]");
+            table.AddRow($"[{theme.PromptCosmosAliasColor} bold]CosmosDB[/]", "");
+            table.AddRow("  Alias", $"[{theme.PromptSessionColor}]{cosmosAlias}[/]");
 
             if (cosmosConfig is not null)
             {
@@ -71,7 +74,7 @@ public sealed class InfoCommand : ICommand
             }
             else
             {
-                table.AddRow("  [dim]Config[/]", "[red]Not found in config[/]");
+                table.AddRow($"  [{theme.DimColor}]Config[/]", $"[{theme.ErrorColor}]Not found in config[/]");
             }
         }
 
@@ -86,8 +89,8 @@ public sealed class InfoCommand : ICommand
         {
             var blobConfig = _configurationService.GetBlobAlias(blobAlias);
 
-            table.AddRow("[magenta bold]Blob Storage[/]", "");
-            table.AddRow("  Alias", $"[cyan]{blobAlias}[/]");
+            table.AddRow($"[{theme.PromptBlobAliasColor} bold]Blob Storage[/]", "");
+            table.AddRow("  Alias", $"[{theme.PromptSessionColor}]{blobAlias}[/]");
 
             if (blobConfig is not null)
             {
@@ -96,7 +99,7 @@ public sealed class InfoCommand : ICommand
             }
             else
             {
-                table.AddRow("  [dim]Config[/]", "[red]Not found in config[/]");
+                table.AddRow($"  [{theme.DimColor}]Config[/]", $"[{theme.ErrorColor}]Not found in config[/]");
             }
         }
 

--- a/src/NimbusStation.Cli/Commands/ThemeCommand.cs
+++ b/src/NimbusStation.Cli/Commands/ThemeCommand.cs
@@ -1,0 +1,227 @@
+using NimbusStation.Cli.Output;
+using NimbusStation.Core.Commands;
+using NimbusStation.Infrastructure.Configuration;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Commands;
+
+/// <summary>
+/// Command for viewing and managing UI themes (list, preview, current).
+/// </summary>
+public sealed class ThemeCommand : ICommand
+{
+    private readonly IConfigurationService _configurationService;
+
+    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "list", "ls", "preview", "current", "presets"
+    };
+
+    /// <inheritdoc/>
+    public string Name => "theme";
+
+    /// <inheritdoc/>
+    public string Description => "View and manage UI themes";
+
+    /// <inheritdoc/>
+    public string Usage => "theme <list|preview|current> [args]";
+
+    /// <inheritdoc/>
+    public IReadOnlySet<string> Subcommands => _subcommands;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThemeCommand"/> class.
+    /// </summary>
+    public ThemeCommand(IConfigurationService configurationService)
+    {
+        _configurationService = configurationService;
+    }
+
+    /// <inheritdoc/>
+    public Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default)
+    {
+        if (args.Length == 0)
+            return Task.FromResult(HandleCurrent(context));
+
+        var subcommand = args[0].ToLowerInvariant();
+        var subArgs = args.Skip(1).ToArray();
+
+        var result = subcommand switch
+        {
+            "list" or "ls" or "presets" => HandleList(context),
+            "preview" => HandlePreview(subArgs, context),
+            "current" => HandleCurrent(context),
+            _ => CommandResult.Error($"Unknown subcommand '{subcommand}'. Usage: {Usage}")
+        };
+
+        return Task.FromResult(result);
+    }
+
+    private CommandResult HandleList(CommandContext context)
+    {
+        var theme = _configurationService.GetTheme();
+        var presetNames = ThemePresets.GetPresetNames().OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(SpectreColorHelper.ParseColorOrDefault(theme.TableBorderColor, Color.Grey));
+
+        table.AddColumn(new TableColumn($"[{theme.TableHeaderColor}]Theme[/]").LeftAligned());
+        table.AddColumn(new TableColumn($"[{theme.TableHeaderColor}]Type[/]").LeftAligned());
+
+        foreach (var name in presetNames)
+        {
+            var themeType = GetThemeType(name);
+            table.AddRow(
+                $"[{theme.PromptSessionColor}]{Markup.Escape(name)}[/]",
+                $"[{theme.DimColor}]{themeType}[/]");
+        }
+
+        context.Output.WriteRenderable(table);
+        context.Output.WriteLine($"[{theme.DimColor}]{presetNames.Count} theme(s) available[/]");
+        context.Output.WriteLine($"[{theme.DimColor}]Use 'theme preview <name>' to preview a theme[/]");
+
+        return CommandResult.Ok(presetNames);
+    }
+
+    private CommandResult HandlePreview(string[] args, CommandContext context)
+    {
+        if (args.Length == 0)
+            return CommandResult.Error("Usage: theme preview <name>");
+
+        var name = args[0];
+        var previewTheme = ThemePresets.GetPreset(name);
+
+        if (previewTheme is null)
+        {
+            var currentTheme = _configurationService.GetTheme();
+            context.Output.WriteLine($"[{currentTheme.ErrorColor}]Theme '{Markup.Escape(name)}' not found.[/]");
+            context.Output.WriteLine($"[{currentTheme.DimColor}]Use 'theme list' to see available themes.[/]");
+            return CommandResult.Error($"Theme '{name}' not found.");
+        }
+
+        PrintThemePreview(previewTheme, name, context);
+
+        return CommandResult.Ok(previewTheme);
+    }
+
+    private CommandResult HandleCurrent(CommandContext context)
+    {
+        var theme = _configurationService.GetTheme();
+
+        context.Output.WriteLine($"[{theme.PromptSessionColor} bold]Current Theme Configuration[/]");
+        context.Output.WriteLine();
+
+        PrintThemeColors(theme, context);
+
+        context.Output.WriteLine();
+        context.Output.WriteLine($"[{theme.DimColor}]Configure in ~/.config/nimbus/config.toml under [theme][/]");
+
+        return CommandResult.Ok(theme);
+    }
+
+    private void PrintThemePreview(ThemeConfig previewTheme, string themeName, CommandContext context)
+    {
+        var currentTheme = _configurationService.GetTheme();
+
+        context.Output.WriteLine($"[{currentTheme.PromptSessionColor} bold]Preview: {Markup.Escape(themeName)}[/]");
+        context.Output.WriteLine();
+
+        // Show a sample prompt using the preview theme colors
+        context.Output.WriteLine($"[{currentTheme.DimColor}]Sample prompt:[/]");
+        var samplePrompt = BuildSamplePrompt(previewTheme);
+        context.Output.WriteLine($"  {samplePrompt}");
+        context.Output.WriteLine();
+
+        // Show sample messages
+        context.Output.WriteLine($"[{currentTheme.DimColor}]Sample messages:[/]");
+        context.Output.WriteLine($"  [{previewTheme.SuccessColor}]Success: Operation completed successfully[/]");
+        context.Output.WriteLine($"  [{previewTheme.WarningColor}]Warning: Configuration may need attention[/]");
+        context.Output.WriteLine($"  [{previewTheme.ErrorColor}]Error: Something went wrong[/]");
+        context.Output.WriteLine($"  [{previewTheme.DimColor}]Hint: This is dimmed helper text[/]");
+        context.Output.WriteLine();
+
+        // Show sample JSON highlighting
+        context.Output.WriteLine($"[{currentTheme.DimColor}]Sample JSON:[/]");
+        context.Output.WriteLine($"  {{");
+        context.Output.WriteLine($"    [{previewTheme.JsonKeyColor}]\"name\"[/]: [{previewTheme.JsonStringColor}]\"example\"[/],");
+        context.Output.WriteLine($"    [{previewTheme.JsonKeyColor}]\"count\"[/]: [{previewTheme.JsonNumberColor}]42[/],");
+        context.Output.WriteLine($"    [{previewTheme.JsonKeyColor}]\"active\"[/]: [{previewTheme.JsonBooleanColor}]true[/],");
+        context.Output.WriteLine($"    [{previewTheme.JsonKeyColor}]\"data\"[/]: [{previewTheme.JsonNullColor}]null[/]");
+        context.Output.WriteLine($"  }}");
+        context.Output.WriteLine();
+
+        // Show color details
+        PrintThemeColors(previewTheme, context);
+
+        context.Output.WriteLine();
+        context.Output.WriteLine($"[{currentTheme.DimColor}]To use this theme, add to ~/.config/nimbus/config.toml:[/]");
+        context.Output.WriteLine($"[{currentTheme.DimColor}]  [theme][/]");
+        context.Output.WriteLine($"[{currentTheme.DimColor}]  preset = \"{Markup.Escape(themeName)}\"[/]");
+    }
+
+    private void PrintThemeColors(ThemeConfig theme, CommandContext context)
+    {
+        var currentTheme = _configurationService.GetTheme();
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(SpectreColorHelper.ParseColorOrDefault(currentTheme.TableBorderColor, Color.Grey));
+
+        table.AddColumn(new TableColumn($"[{currentTheme.TableHeaderColor}]Property[/]").LeftAligned());
+        table.AddColumn(new TableColumn($"[{currentTheme.TableHeaderColor}]Value[/]").LeftAligned());
+        table.AddColumn(new TableColumn($"[{currentTheme.TableHeaderColor}]Preview[/]").LeftAligned());
+
+        AddColorRow(table, "prompt_color", theme.PromptColor);
+        AddColorRow(table, "prompt_session_color", theme.PromptSessionColor);
+        AddColorRow(table, "prompt_context_color", theme.PromptContextColor);
+        AddColorRow(table, "prompt_cosmos_alias_color", theme.PromptCosmosAliasColor);
+        AddColorRow(table, "prompt_blob_alias_color", theme.PromptBlobAliasColor);
+        AddColorRow(table, "table_header_color", theme.TableHeaderColor);
+        AddColorRow(table, "table_border_color", theme.TableBorderColor);
+        AddColorRow(table, "error_color", theme.ErrorColor);
+        AddColorRow(table, "warning_color", theme.WarningColor);
+        AddColorRow(table, "success_color", theme.SuccessColor);
+        AddColorRow(table, "dim_color", theme.DimColor);
+        AddColorRow(table, "json_key_color", theme.JsonKeyColor);
+        AddColorRow(table, "json_string_color", theme.JsonStringColor);
+        AddColorRow(table, "json_number_color", theme.JsonNumberColor);
+        AddColorRow(table, "json_boolean_color", theme.JsonBooleanColor);
+        AddColorRow(table, "json_null_color", theme.JsonNullColor);
+        AddColorRow(table, "banner_color", theme.BannerColor);
+
+        context.Output.WriteRenderable(table);
+    }
+
+    private static void AddColorRow(Table table, string propertyName, string colorValue)
+    {
+        var escapedValue = Markup.Escape(colorValue);
+        table.AddRow(
+            propertyName,
+            escapedValue,
+            $"[{colorValue}]{escapedValue}[/]");
+    }
+
+    private static string BuildSamplePrompt(ThemeConfig theme)
+    {
+        var prompt = $"[{theme.PromptColor}]ns[/]";
+        prompt += $" [{theme.PromptSessionColor}]TICKET-123[/]";
+        prompt += $" [{theme.PromptContextColor}][[/]";
+        prompt += $"[{theme.PromptCosmosAliasColor}]prod-cosmos[/]";
+        prompt += $"[{theme.PromptContextColor}]/[/]";
+        prompt += $"[{theme.PromptBlobAliasColor}]prod-blob[/]";
+        prompt += $"[{theme.PromptContextColor}]][/]";
+        prompt += $"[{theme.PromptColor}]>[/] ";
+        return prompt;
+    }
+
+    private static string GetThemeType(string name) =>
+        name switch
+        {
+            "default" => "built-in",
+            _ when name.Contains("light", StringComparison.OrdinalIgnoreCase) => "light",
+            _ when name.Contains("latte", StringComparison.OrdinalIgnoreCase) => "light",
+            _ when name.Contains("day", StringComparison.OrdinalIgnoreCase) => "light",
+            _ => "dark"
+        };
+}

--- a/src/NimbusStation.Cli/Commands/UseCommand.cs
+++ b/src/NimbusStation.Cli/Commands/UseCommand.cs
@@ -68,19 +68,20 @@ public sealed class UseCommand : ICommand
         };
     }
 
-    private static CommandResult HandleShowContext(CommandContext context)
+    private CommandResult HandleShowContext(CommandContext context)
     {
         var session = context.CurrentSession!;
         var activeContext = session.ActiveContext;
+        var theme = _configurationService.GetTheme();
 
         var cosmosAlias = activeContext?.ActiveCosmosAlias ?? "(none)";
         var blobAlias = activeContext?.ActiveBlobAlias ?? "(none)";
         var storageAlias = activeContext?.ActiveStorageAlias ?? "(none)";
 
         context.Output.WriteLine("[bold]Active contexts:[/]");
-        context.Output.WriteLine($"  [orange1]cosmos:[/]   {cosmosAlias}");
-        context.Output.WriteLine($"  [magenta]blob:[/]     {blobAlias}");
-        context.Output.WriteLine($"  [blue]storage:[/]  {storageAlias}");
+        context.Output.WriteLine($"  [{theme.PromptCosmosAliasColor}]cosmos:[/]   {cosmosAlias}");
+        context.Output.WriteLine($"  [{theme.PromptBlobAliasColor}]blob:[/]     {blobAlias}");
+        context.Output.WriteLine($"  [{theme.TableHeaderColor}]storage:[/]  {storageAlias}");
 
         return CommandResult.Ok();
     }
@@ -91,6 +92,7 @@ public sealed class UseCommand : ICommand
             return CommandResult.Error("Usage: use cosmos <alias>");
 
         var aliasName = args[0];
+        var theme = _configurationService.GetTheme();
         var aliasConfig = _configurationService.GetCosmosAlias(aliasName);
 
         if (aliasConfig is null)
@@ -105,8 +107,8 @@ public sealed class UseCommand : ICommand
             context.CurrentSession.ActiveContext!,
             cancellationToken);
 
-        context.Output.WriteLine($"[green]Context set:[/] [orange1]cosmos/{aliasName}[/]");
-        context.Output.WriteLine($"[dim]Endpoint: {aliasConfig.Endpoint}[/]");
+        context.Output.WriteLine($"[{theme.SuccessColor}]Context set:[/] [{theme.PromptCosmosAliasColor}]cosmos/{aliasName}[/]");
+        context.Output.WriteLine($"[{theme.DimColor}]Endpoint: {aliasConfig.Endpoint}[/]");
 
         return CommandResult.Ok();
     }
@@ -117,6 +119,7 @@ public sealed class UseCommand : ICommand
             return CommandResult.Error("Usage: use blob <alias>");
 
         var aliasName = args[0];
+        var theme = _configurationService.GetTheme();
         var aliasConfig = _configurationService.GetBlobAlias(aliasName);
 
         if (aliasConfig is null)
@@ -131,8 +134,8 @@ public sealed class UseCommand : ICommand
             context.CurrentSession.ActiveContext!,
             cancellationToken);
 
-        context.Output.WriteLine($"[green]Context set:[/] [magenta]blob/{aliasName}[/]");
-        context.Output.WriteLine($"[dim]Account: {aliasConfig.Account}[/]");
+        context.Output.WriteLine($"[{theme.SuccessColor}]Context set:[/] [{theme.PromptBlobAliasColor}]blob/{aliasName}[/]");
+        context.Output.WriteLine($"[{theme.DimColor}]Account: {aliasConfig.Account}[/]");
 
         return CommandResult.Ok();
     }
@@ -143,6 +146,7 @@ public sealed class UseCommand : ICommand
             return CommandResult.Error("Usage: use storage <alias>");
 
         var aliasName = args[0];
+        var theme = _configurationService.GetTheme();
         var aliasConfig = _configurationService.GetStorageAlias(aliasName);
 
         if (aliasConfig is null)
@@ -157,8 +161,8 @@ public sealed class UseCommand : ICommand
             context.CurrentSession.ActiveContext!,
             cancellationToken);
 
-        context.Output.WriteLine($"[green]Context set:[/] [blue]storage/{aliasName}[/]");
-        context.Output.WriteLine($"[dim]Account: {aliasConfig.Account}[/]");
+        context.Output.WriteLine($"[{theme.SuccessColor}]Context set:[/] [{theme.TableHeaderColor}]storage/{aliasName}[/]");
+        context.Output.WriteLine($"[{theme.DimColor}]Account: {aliasConfig.Account}[/]");
 
         return CommandResult.Ok();
     }
@@ -202,7 +206,8 @@ public sealed class UseCommand : ICommand
             context.CurrentSession.ActiveContext ?? SessionContext.Empty,
             cancellationToken);
 
-        context.Output.WriteLine($"[yellow]{message}[/]");
+        var theme = _configurationService.GetTheme();
+        context.Output.WriteLine($"[{theme.WarningColor}]{message}[/]");
 
         return CommandResult.Ok();
     }

--- a/src/NimbusStation.Cli/Output/BannerPrinter.cs
+++ b/src/NimbusStation.Cli/Output/BannerPrinter.cs
@@ -1,0 +1,28 @@
+using NimbusStation.Infrastructure.Configuration;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Output;
+
+/// <summary>
+/// Prints the startup banner with theme-aware colors.
+/// </summary>
+public static class BannerPrinter
+{
+    /// <summary>
+    /// Prints the Nimbus Station banner using the specified theme.
+    /// </summary>
+    /// <param name="theme">The theme configuration for colors.</param>
+    /// <param name="version">The application version to display.</param>
+    public static void Print(ThemeConfig theme, string version)
+    {
+        var bannerColor = SpectreColorHelper.ParseColorOrDefault(theme.BannerColor, Color.Cyan1);
+
+        AnsiConsole.Write(
+            new FigletText("Nimbus Station")
+                .LeftJustified()
+                .Color(bannerColor));
+
+        AnsiConsole.MarkupLine($"[{theme.DimColor}]Cloud-agnostic investigation workbench v{version}[/]");
+        AnsiConsole.WriteLine();
+    }
+}

--- a/src/NimbusStation.Cli/Output/SpectreColorHelper.cs
+++ b/src/NimbusStation.Cli/Output/SpectreColorHelper.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using System.Reflection;
+using NimbusStation.Infrastructure.Configuration;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Output;
+
+/// <summary>
+/// Helper for parsing theme color strings into Spectre.Console Color objects.
+/// Supports named colors (e.g., "green"), hex codes (e.g., "#50FA7B"),
+/// and RGB values (e.g., "rgb(80,250,123)").
+/// </summary>
+public static class SpectreColorHelper
+{
+    /// <summary>
+    /// Validates whether a string represents a valid color format.
+    /// Delegates to <see cref="ColorFormatValidator.IsValid"/> for consistent validation.
+    /// </summary>
+    /// <param name="color">The color string to validate.</param>
+    /// <returns>True if the color string is valid; otherwise, false.</returns>
+    public static bool IsValidColor(string color) => ColorFormatValidator.IsValid(color);
+
+    /// <summary>
+    /// Parses a color string into a Spectre.Console Color.
+    /// </summary>
+    /// <param name="colorString">The color string to parse.</param>
+    /// <returns>The parsed Color, or null if parsing failed.</returns>
+    public static Color? TryParseColor(string colorString)
+    {
+        if (string.IsNullOrWhiteSpace(colorString))
+            return null;
+
+        try
+        {
+            if (colorString.StartsWith('#'))
+                return ParseHexColor(colorString);
+
+            if (colorString.StartsWith("rgb(", StringComparison.OrdinalIgnoreCase) && colorString.EndsWith(')'))
+                return ParseRgbColor(colorString);
+
+            return ParseNamedColor(colorString);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a color string into a Spectre.Console Color, returning a fallback if parsing fails.
+    /// </summary>
+    /// <param name="colorString">The color string to parse.</param>
+    /// <param name="fallback">The fallback color to use if parsing fails.</param>
+    /// <returns>The parsed Color, or the fallback if parsing failed.</returns>
+    public static Color ParseColorOrDefault(string colorString, Color fallback) =>
+        TryParseColor(colorString) ?? fallback;
+
+    private static Color? ParseHexColor(string colorString)
+    {
+        var hex = colorString[1..];
+
+        // Expand #RGB to #RRGGBB
+        if (hex.Length == 3)
+            hex = string.Concat(hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]);
+
+        if (hex.Length != 6)
+            return null;
+
+        if (byte.TryParse(hex[..2], NumberStyles.HexNumber, null, out var r) &&
+            byte.TryParse(hex[2..4], NumberStyles.HexNumber, null, out var g) &&
+            byte.TryParse(hex[4..6], NumberStyles.HexNumber, null, out var b))
+        {
+            return new Color(r, g, b);
+        }
+
+        return null;
+    }
+
+    private static Color? ParseRgbColor(string colorString)
+    {
+        var inner = colorString[4..^1];
+        var parts = inner.Split(',');
+
+        if (parts.Length != 3)
+            return null;
+
+        if (byte.TryParse(parts[0].Trim(), out var r) &&
+            byte.TryParse(parts[1].Trim(), out var g) &&
+            byte.TryParse(parts[2].Trim(), out var b))
+        {
+            return new Color(r, g, b);
+        }
+
+        return null;
+    }
+
+    private static Color? ParseNamedColor(string colorString)
+    {
+        var colorProperty = typeof(Color).GetProperty(
+            colorString,
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase);
+
+        return colorProperty?.GetValue(null) as Color?;
+    }
+}

--- a/src/NimbusStation.Infrastructure/Configuration/ColorFormatValidator.cs
+++ b/src/NimbusStation.Infrastructure/Configuration/ColorFormatValidator.cs
@@ -1,0 +1,49 @@
+namespace NimbusStation.Infrastructure.Configuration;
+
+/// <summary>
+/// Validates color format strings for theme configuration.
+/// Supports named colors (e.g., "green"), hex codes (e.g., "#50FA7B"),
+/// and RGB values (e.g., "rgb(80,250,123)").
+/// </summary>
+public static class ColorFormatValidator
+{
+    /// <summary>
+    /// Validates whether a string represents a valid color format.
+    /// </summary>
+    /// <param name="color">The color string to validate.</param>
+    /// <returns>True if the color string format is valid; otherwise, false.</returns>
+    public static bool IsValid(string color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+            return false;
+
+        if (color.StartsWith('#'))
+            return IsValidHexColor(color);
+
+        if (color.StartsWith("rgb(", StringComparison.OrdinalIgnoreCase) && color.EndsWith(')'))
+            return IsValidRgbColor(color);
+
+        return IsValidNamedColor(color);
+    }
+
+    private static bool IsValidHexColor(string color)
+    {
+        var hex = color[1..];
+        return (hex.Length == 3 || hex.Length == 6) &&
+               hex.All(c => char.IsAsciiHexDigit(c));
+    }
+
+    private static bool IsValidRgbColor(string color)
+    {
+        var inner = color[4..^1];
+        var parts = inner.Split(',');
+        return parts.Length == 3 && parts.All(p => byte.TryParse(p.Trim(), out _));
+    }
+
+    // Note: This method validates the syntactic format of a named color (alphanumeric only).
+    // It does not verify that the name corresponds to an actual Spectre.Console Color.
+    // Semantic validation occurs when the value is parsed by SpectreColorHelper.
+    // The alphanumeric restriction also prevents markup injection (no brackets allowed).
+    private static bool IsValidNamedColor(string color) =>
+        color.All(c => char.IsLetter(c) || char.IsDigit(c));
+}

--- a/src/NimbusStation.Infrastructure/Configuration/ConfigurationService.cs
+++ b/src/NimbusStation.Infrastructure/Configuration/ConfigurationService.cs
@@ -16,9 +16,35 @@ public sealed class ConfigurationService : IConfigurationService
 
         # Theme settings for terminal output
         # [theme]
+        # Use a preset theme as a base (optional):
+        # preset = "catppuccin-mocha"
+        #
+        # Available presets: default, catppuccin-mocha, catppuccin-macchiato,
+        # catppuccin-frappe, catppuccin-latte, dracula, one-dark, gruvbox-dark,
+        # gruvbox-light, ayu-dark, ayu-mirage, ayu-light, github-dark, github-light,
+        # xcode-dark, xcode-light, tokyonight-night, tokyonight-storm, tokyonight-day,
+        # nord, vscode-dark, vscode-light, material-darker, material-ocean,
+        # material-palenight, solarized-dark, solarized-light
+        #
+        # Override individual colors (supports color names, hex codes like "#50FA7B",
+        # or rgb values like "rgb(80,250,123)"):
         # prompt_color = "green"
+        # prompt_session_color = "cyan"
+        # prompt_context_color = "yellow"
+        # prompt_cosmos_alias_color = "orange1"
+        # prompt_blob_alias_color = "magenta"
         # table_header_color = "blue"
+        # table_border_color = "grey"
+        # error_color = "red"
+        # warning_color = "yellow"
+        # success_color = "green"
+        # dim_color = "grey"
         # json_key_color = "cyan"
+        # json_string_color = "green"
+        # json_number_color = "magenta"
+        # json_boolean_color = "yellow"
+        # json_null_color = "grey"
+        # banner_color = "cyan1"
 
         # CosmosDB connection aliases
         # [aliases.cosmos]
@@ -165,11 +191,79 @@ public sealed class ConfigurationService : IConfigurationService
             return;
         }
 
-        var promptColor = GetStringValue(themeTable, "prompt_color") ?? ThemeConfig.Default.PromptColor;
-        var tableHeaderColor = GetStringValue(themeTable, "table_header_color") ?? ThemeConfig.Default.TableHeaderColor;
-        var jsonKeyColor = GetStringValue(themeTable, "json_key_color") ?? ThemeConfig.Default.JsonKeyColor;
+        // Start with default theme, or a preset if specified
+        var baseTheme = ThemeConfig.Default;
+        var presetName = GetStringValue(themeTable, "preset");
+        if (!string.IsNullOrEmpty(presetName))
+        {
+            var preset = ThemePresets.GetPreset(presetName);
+            if (preset is not null)
+            {
+                baseTheme = preset;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Unknown theme preset '{PresetName}'. Using default theme. Available presets: {Presets}",
+                    presetName,
+                    string.Join(", ", ThemePresets.GetPresetNames()));
+            }
+        }
 
-        config.Theme = new ThemeConfig(promptColor, tableHeaderColor, jsonKeyColor);
+        // Parse each color property with validation, falling back to base theme values
+        var promptColor = ValidateColor(themeTable, "prompt_color", baseTheme.PromptColor);
+        var promptSessionColor = ValidateColor(themeTable, "prompt_session_color", baseTheme.PromptSessionColor);
+        var promptContextColor = ValidateColor(themeTable, "prompt_context_color", baseTheme.PromptContextColor);
+        var promptCosmosAliasColor = ValidateColor(themeTable, "prompt_cosmos_alias_color", baseTheme.PromptCosmosAliasColor);
+        var promptBlobAliasColor = ValidateColor(themeTable, "prompt_blob_alias_color", baseTheme.PromptBlobAliasColor);
+        var tableHeaderColor = ValidateColor(themeTable, "table_header_color", baseTheme.TableHeaderColor);
+        var tableBorderColor = ValidateColor(themeTable, "table_border_color", baseTheme.TableBorderColor);
+        var errorColor = ValidateColor(themeTable, "error_color", baseTheme.ErrorColor);
+        var warningColor = ValidateColor(themeTable, "warning_color", baseTheme.WarningColor);
+        var successColor = ValidateColor(themeTable, "success_color", baseTheme.SuccessColor);
+        var dimColor = ValidateColor(themeTable, "dim_color", baseTheme.DimColor);
+        var jsonKeyColor = ValidateColor(themeTable, "json_key_color", baseTheme.JsonKeyColor);
+        var jsonStringColor = ValidateColor(themeTable, "json_string_color", baseTheme.JsonStringColor);
+        var jsonNumberColor = ValidateColor(themeTable, "json_number_color", baseTheme.JsonNumberColor);
+        var jsonBooleanColor = ValidateColor(themeTable, "json_boolean_color", baseTheme.JsonBooleanColor);
+        var jsonNullColor = ValidateColor(themeTable, "json_null_color", baseTheme.JsonNullColor);
+        var bannerColor = ValidateColor(themeTable, "banner_color", baseTheme.BannerColor);
+
+        config.Theme = new ThemeConfig(
+            PromptColor: promptColor,
+            PromptSessionColor: promptSessionColor,
+            PromptContextColor: promptContextColor,
+            PromptCosmosAliasColor: promptCosmosAliasColor,
+            PromptBlobAliasColor: promptBlobAliasColor,
+            TableHeaderColor: tableHeaderColor,
+            TableBorderColor: tableBorderColor,
+            ErrorColor: errorColor,
+            WarningColor: warningColor,
+            SuccessColor: successColor,
+            DimColor: dimColor,
+            JsonKeyColor: jsonKeyColor,
+            JsonStringColor: jsonStringColor,
+            JsonNumberColor: jsonNumberColor,
+            JsonBooleanColor: jsonBooleanColor,
+            JsonNullColor: jsonNullColor,
+            BannerColor: bannerColor);
+    }
+
+    private string ValidateColor(TomlTable table, string key, string defaultValue)
+    {
+        var value = GetStringValue(table, key);
+        if (string.IsNullOrEmpty(value))
+            return defaultValue;
+
+        if (ColorFormatValidator.IsValid(value))
+            return value;
+
+        _logger.LogWarning(
+            "Invalid color value '{ColorValue}' for theme property '{PropertyName}'. Using default: {DefaultValue}",
+            value,
+            key,
+            defaultValue);
+        return defaultValue;
     }
 
     private void ParseCosmosAliases(TomlTable tomlTable, NimbusConfiguration config)

--- a/src/NimbusStation.Infrastructure/Configuration/ThemeConfig.cs
+++ b/src/NimbusStation.Infrastructure/Configuration/ThemeConfig.cs
@@ -2,14 +2,64 @@ namespace NimbusStation.Infrastructure.Configuration;
 
 /// <summary>
 /// Configuration for terminal theme colors.
+/// All colors support Spectre.Console color names (e.g., "green", "cyan"),
+/// hex codes (e.g., "#50FA7B"), or RGB values (e.g., "rgb(80,250,123)").
 /// </summary>
-/// <param name="PromptColor">Color for the REPL prompt.</param>
+/// <param name="PromptColor">Color for the main prompt text (e.g., "ns").</param>
+/// <param name="PromptSessionColor">Color for the session/ticket ID in the prompt.</param>
+/// <param name="PromptContextColor">Color for context brackets in the prompt.</param>
+/// <param name="PromptCosmosAliasColor">Color for the active Cosmos alias in the prompt.</param>
+/// <param name="PromptBlobAliasColor">Color for the active Blob alias in the prompt.</param>
 /// <param name="TableHeaderColor">Color for table headers.</param>
-/// <param name="JsonKeyColor">Color for JSON keys in output.</param>
-public sealed record ThemeConfig(string PromptColor, string TableHeaderColor, string JsonKeyColor)
+/// <param name="TableBorderColor">Color for table borders.</param>
+/// <param name="ErrorColor">Color for error messages.</param>
+/// <param name="WarningColor">Color for warning messages.</param>
+/// <param name="SuccessColor">Color for success messages.</param>
+/// <param name="DimColor">Color for muted/hint text.</param>
+/// <param name="JsonKeyColor">Color for JSON object keys.</param>
+/// <param name="JsonStringColor">Color for JSON string values.</param>
+/// <param name="JsonNumberColor">Color for JSON number values.</param>
+/// <param name="JsonBooleanColor">Color for JSON boolean values.</param>
+/// <param name="JsonNullColor">Color for JSON null values.</param>
+/// <param name="BannerColor">Color for the startup banner.</param>
+public sealed record ThemeConfig(
+    string PromptColor,
+    string PromptSessionColor,
+    string PromptContextColor,
+    string PromptCosmosAliasColor,
+    string PromptBlobAliasColor,
+    string TableHeaderColor,
+    string TableBorderColor,
+    string ErrorColor,
+    string WarningColor,
+    string SuccessColor,
+    string DimColor,
+    string JsonKeyColor,
+    string JsonStringColor,
+    string JsonNumberColor,
+    string JsonBooleanColor,
+    string JsonNullColor,
+    string BannerColor)
 {
     /// <summary>
     /// Gets the default theme configuration.
     /// </summary>
-    public static ThemeConfig Default { get; } = new("green", "blue", "cyan");
+    public static ThemeConfig Default { get; } = new(
+        PromptColor: "green",
+        PromptSessionColor: "cyan",
+        PromptContextColor: "yellow",
+        PromptCosmosAliasColor: "orange1",
+        PromptBlobAliasColor: "magenta",
+        TableHeaderColor: "blue",
+        TableBorderColor: "grey",
+        ErrorColor: "red",
+        WarningColor: "yellow",
+        SuccessColor: "green",
+        DimColor: "grey",
+        JsonKeyColor: "cyan",
+        JsonStringColor: "green",
+        JsonNumberColor: "magenta",
+        JsonBooleanColor: "yellow",
+        JsonNullColor: "grey",
+        BannerColor: "cyan1");
 }

--- a/src/NimbusStation.Infrastructure/Configuration/ThemePresets.cs
+++ b/src/NimbusStation.Infrastructure/Configuration/ThemePresets.cs
@@ -1,0 +1,623 @@
+namespace NimbusStation.Infrastructure.Configuration;
+
+/// <summary>
+/// Provides preset theme configurations for popular color schemes.
+/// </summary>
+public static class ThemePresets
+{
+    // ========== Catppuccin Themes ==========
+
+    /// <summary>Catppuccin Mocha - dark, warm flavor.</summary>
+    public static ThemeConfig CatppuccinMocha { get; } = new(
+        PromptColor: "#a6e3a1",        // Green
+        PromptSessionColor: "#89dceb", // Sky
+        PromptContextColor: "#f9e2af", // Yellow
+        PromptCosmosAliasColor: "#fab387", // Peach
+        PromptBlobAliasColor: "#cba6f7", // Mauve
+        TableHeaderColor: "#89b4fa",   // Blue
+        TableBorderColor: "#6c7086",   // Overlay0
+        ErrorColor: "#f38ba8",         // Red
+        WarningColor: "#f9e2af",       // Yellow
+        SuccessColor: "#a6e3a1",       // Green
+        DimColor: "#6c7086",           // Overlay0
+        JsonKeyColor: "#89b4fa",       // Blue
+        JsonStringColor: "#a6e3a1",    // Green
+        JsonNumberColor: "#fab387",    // Peach
+        JsonBooleanColor: "#f9e2af",   // Yellow
+        JsonNullColor: "#6c7086",      // Overlay0
+        BannerColor: "#89dceb");       // Sky
+
+    /// <summary>Catppuccin Macchiato - dark, slightly lighter.</summary>
+    public static ThemeConfig CatppuccinMacchiato { get; } = new(
+        PromptColor: "#a6da95",        // Green
+        PromptSessionColor: "#91d7e3", // Sky
+        PromptContextColor: "#eed49f", // Yellow
+        PromptCosmosAliasColor: "#f5a97f", // Peach
+        PromptBlobAliasColor: "#c6a0f6", // Mauve
+        TableHeaderColor: "#8aadf4",   // Blue
+        TableBorderColor: "#6e738d",   // Overlay0
+        ErrorColor: "#ed8796",         // Red
+        WarningColor: "#eed49f",       // Yellow
+        SuccessColor: "#a6da95",       // Green
+        DimColor: "#6e738d",           // Overlay0
+        JsonKeyColor: "#8aadf4",       // Blue
+        JsonStringColor: "#a6da95",    // Green
+        JsonNumberColor: "#f5a97f",    // Peach
+        JsonBooleanColor: "#eed49f",   // Yellow
+        JsonNullColor: "#6e738d",      // Overlay0
+        BannerColor: "#91d7e3");       // Sky
+
+    /// <summary>Catppuccin Frappé - medium contrast.</summary>
+    public static ThemeConfig CatppuccinFrappe { get; } = new(
+        PromptColor: "#a6d189",        // Green
+        PromptSessionColor: "#99d1db", // Sky
+        PromptContextColor: "#e5c890", // Yellow
+        PromptCosmosAliasColor: "#ef9f76", // Peach
+        PromptBlobAliasColor: "#ca9ee6", // Mauve
+        TableHeaderColor: "#8caaee",   // Blue
+        TableBorderColor: "#737994",   // Overlay0
+        ErrorColor: "#e78284",         // Red
+        WarningColor: "#e5c890",       // Yellow
+        SuccessColor: "#a6d189",       // Green
+        DimColor: "#737994",           // Overlay0
+        JsonKeyColor: "#8caaee",       // Blue
+        JsonStringColor: "#a6d189",    // Green
+        JsonNumberColor: "#ef9f76",    // Peach
+        JsonBooleanColor: "#e5c890",   // Yellow
+        JsonNullColor: "#737994",      // Overlay0
+        BannerColor: "#99d1db");       // Sky
+
+    /// <summary>Catppuccin Latte - light theme.</summary>
+    public static ThemeConfig CatppuccinLatte { get; } = new(
+        PromptColor: "#40a02b",        // Green
+        PromptSessionColor: "#04a5e5", // Sky
+        PromptContextColor: "#df8e1d", // Yellow
+        PromptCosmosAliasColor: "#fe640b", // Peach
+        PromptBlobAliasColor: "#8839ef", // Mauve
+        TableHeaderColor: "#1e66f5",   // Blue
+        TableBorderColor: "#9ca0b0",   // Overlay0
+        ErrorColor: "#d20f39",         // Red
+        WarningColor: "#df8e1d",       // Yellow
+        SuccessColor: "#40a02b",       // Green
+        DimColor: "#9ca0b0",           // Overlay0
+        JsonKeyColor: "#1e66f5",       // Blue
+        JsonStringColor: "#40a02b",    // Green
+        JsonNumberColor: "#fe640b",    // Peach
+        JsonBooleanColor: "#df8e1d",   // Yellow
+        JsonNullColor: "#9ca0b0",      // Overlay0
+        BannerColor: "#04a5e5");       // Sky
+
+    // ========== Dracula ==========
+
+    /// <summary>Dracula - dark theme with vibrant colors.</summary>
+    public static ThemeConfig Dracula { get; } = new(
+        PromptColor: "#50fa7b",        // Green
+        PromptSessionColor: "#8be9fd", // Cyan
+        PromptContextColor: "#f1fa8c", // Yellow
+        PromptCosmosAliasColor: "#ffb86c", // Orange
+        PromptBlobAliasColor: "#bd93f9", // Purple
+        TableHeaderColor: "#8be9fd",   // Cyan
+        TableBorderColor: "#6272a4",   // Comment
+        ErrorColor: "#ff5555",         // Red
+        WarningColor: "#f1fa8c",       // Yellow
+        SuccessColor: "#50fa7b",       // Green
+        DimColor: "#6272a4",           // Comment
+        JsonKeyColor: "#8be9fd",       // Cyan
+        JsonStringColor: "#f1fa8c",    // Yellow
+        JsonNumberColor: "#bd93f9",    // Purple
+        JsonBooleanColor: "#ff79c6",   // Pink
+        JsonNullColor: "#6272a4",      // Comment
+        BannerColor: "#bd93f9");       // Purple
+
+    // ========== One Dark ==========
+
+    /// <summary>One Dark - Atom's iconic dark theme.</summary>
+    public static ThemeConfig OneDark { get; } = new(
+        PromptColor: "#98c379",        // Green
+        PromptSessionColor: "#56b6c2", // Cyan
+        PromptContextColor: "#e5c07b", // Yellow
+        PromptCosmosAliasColor: "#d19a66", // Orange
+        PromptBlobAliasColor: "#c678dd", // Purple
+        TableHeaderColor: "#61afef",   // Blue
+        TableBorderColor: "#5c6370",   // Comment
+        ErrorColor: "#e06c75",         // Red
+        WarningColor: "#e5c07b",       // Yellow
+        SuccessColor: "#98c379",       // Green
+        DimColor: "#5c6370",           // Comment
+        JsonKeyColor: "#61afef",       // Blue
+        JsonStringColor: "#98c379",    // Green
+        JsonNumberColor: "#d19a66",    // Orange
+        JsonBooleanColor: "#e5c07b",   // Yellow
+        JsonNullColor: "#5c6370",      // Comment
+        BannerColor: "#61afef");       // Blue
+
+    // ========== Gruvbox ==========
+
+    /// <summary>Gruvbox Dark - retro groove dark theme.</summary>
+    public static ThemeConfig GruvboxDark { get; } = new(
+        PromptColor: "#b8bb26",        // Green
+        PromptSessionColor: "#83a598", // Aqua
+        PromptContextColor: "#fabd2f", // Yellow
+        PromptCosmosAliasColor: "#fe8019", // Orange
+        PromptBlobAliasColor: "#d3869b", // Purple
+        TableHeaderColor: "#83a598",   // Aqua
+        TableBorderColor: "#504945",   // Dark gray
+        ErrorColor: "#fb4934",         // Red
+        WarningColor: "#fabd2f",       // Yellow
+        SuccessColor: "#b8bb26",       // Green
+        DimColor: "#928374",           // Gray
+        JsonKeyColor: "#83a598",       // Aqua
+        JsonStringColor: "#b8bb26",    // Green
+        JsonNumberColor: "#d3869b",    // Purple
+        JsonBooleanColor: "#fabd2f",   // Yellow
+        JsonNullColor: "#928374",      // Gray
+        BannerColor: "#83a598");       // Aqua
+
+    /// <summary>Gruvbox Light - retro groove light theme.</summary>
+    public static ThemeConfig GruvboxLight { get; } = new(
+        PromptColor: "#79740e",        // Green
+        PromptSessionColor: "#427b58", // Aqua
+        PromptContextColor: "#b57614", // Yellow
+        PromptCosmosAliasColor: "#af3a03", // Orange
+        PromptBlobAliasColor: "#8f3f71", // Purple
+        TableHeaderColor: "#427b58",   // Aqua
+        TableBorderColor: "#d5c4a1",   // Light gray
+        ErrorColor: "#9d0006",         // Red
+        WarningColor: "#b57614",       // Yellow
+        SuccessColor: "#79740e",       // Green
+        DimColor: "#928374",           // Gray
+        JsonKeyColor: "#427b58",       // Aqua
+        JsonStringColor: "#79740e",    // Green
+        JsonNumberColor: "#8f3f71",    // Purple
+        JsonBooleanColor: "#b57614",   // Yellow
+        JsonNullColor: "#928374",      // Gray
+        BannerColor: "#427b58");       // Aqua
+
+    // ========== Ayu ==========
+
+    /// <summary>Ayu Dark - elegant dark theme.</summary>
+    public static ThemeConfig AyuDark { get; } = new(
+        PromptColor: "#aad94c",        // Green
+        PromptSessionColor: "#73b8ff", // Blue
+        PromptContextColor: "#ffb454", // Yellow
+        PromptCosmosAliasColor: "#ff8f40", // Orange
+        PromptBlobAliasColor: "#d2a6ff", // Purple
+        TableHeaderColor: "#73b8ff",   // Blue
+        TableBorderColor: "#565b66",   // Gray
+        ErrorColor: "#f07178",         // Red
+        WarningColor: "#ffb454",       // Yellow
+        SuccessColor: "#aad94c",       // Green
+        DimColor: "#565b66",           // Gray
+        JsonKeyColor: "#73b8ff",       // Blue
+        JsonStringColor: "#aad94c",    // Green
+        JsonNumberColor: "#d2a6ff",    // Purple
+        JsonBooleanColor: "#ffb454",   // Yellow
+        JsonNullColor: "#565b66",      // Gray
+        BannerColor: "#73b8ff");       // Blue
+
+    /// <summary>Ayu Mirage - dark with warmer tones.</summary>
+    public static ThemeConfig AyuMirage { get; } = new(
+        PromptColor: "#d5ff80",        // Green
+        PromptSessionColor: "#73d0ff", // Blue
+        PromptContextColor: "#ffd173", // Yellow
+        PromptCosmosAliasColor: "#ffad66", // Orange
+        PromptBlobAliasColor: "#dfbfff", // Purple
+        TableHeaderColor: "#73d0ff",   // Blue
+        TableBorderColor: "#5c6773",   // Gray
+        ErrorColor: "#ff6666",         // Red
+        WarningColor: "#ffd173",       // Yellow
+        SuccessColor: "#d5ff80",       // Green
+        DimColor: "#5c6773",           // Gray
+        JsonKeyColor: "#73d0ff",       // Blue
+        JsonStringColor: "#d5ff80",    // Green
+        JsonNumberColor: "#dfbfff",    // Purple
+        JsonBooleanColor: "#ffd173",   // Yellow
+        JsonNullColor: "#5c6773",      // Gray
+        BannerColor: "#73d0ff");       // Blue
+
+    /// <summary>Ayu Light - elegant light theme.</summary>
+    public static ThemeConfig AyuLight { get; } = new(
+        PromptColor: "#86b300",        // Green
+        PromptSessionColor: "#399ee6", // Blue
+        PromptContextColor: "#f2ae49", // Yellow
+        PromptCosmosAliasColor: "#fa8d3e", // Orange
+        PromptBlobAliasColor: "#a37acc", // Purple
+        TableHeaderColor: "#399ee6",   // Blue
+        TableBorderColor: "#8a9199",   // Gray
+        ErrorColor: "#f51818",         // Red
+        WarningColor: "#f2ae49",       // Yellow
+        SuccessColor: "#86b300",       // Green
+        DimColor: "#8a9199",           // Gray
+        JsonKeyColor: "#399ee6",       // Blue
+        JsonStringColor: "#86b300",    // Green
+        JsonNumberColor: "#a37acc",    // Purple
+        JsonBooleanColor: "#f2ae49",   // Yellow
+        JsonNullColor: "#8a9199",      // Gray
+        BannerColor: "#399ee6");       // Blue
+
+    // ========== GitHub ==========
+
+    /// <summary>GitHub Dark - GitHub's dark mode.</summary>
+    public static ThemeConfig GitHubDark { get; } = new(
+        PromptColor: "#3fb950",        // Green
+        PromptSessionColor: "#58a6ff", // Blue
+        PromptContextColor: "#d29922", // Yellow
+        PromptCosmosAliasColor: "#db6d28", // Orange
+        PromptBlobAliasColor: "#a371f7", // Purple
+        TableHeaderColor: "#58a6ff",   // Blue
+        TableBorderColor: "#484f58",   // Gray
+        ErrorColor: "#f85149",         // Red
+        WarningColor: "#d29922",       // Yellow
+        SuccessColor: "#3fb950",       // Green
+        DimColor: "#484f58",           // Gray
+        JsonKeyColor: "#58a6ff",       // Blue
+        JsonStringColor: "#a5d6ff",    // Light blue
+        JsonNumberColor: "#a371f7",    // Purple
+        JsonBooleanColor: "#d29922",   // Yellow
+        JsonNullColor: "#484f58",      // Gray
+        BannerColor: "#58a6ff");       // Blue
+
+    /// <summary>GitHub Light - GitHub's light mode.</summary>
+    public static ThemeConfig GitHubLight { get; } = new(
+        PromptColor: "#1a7f37",        // Green
+        PromptSessionColor: "#0969da", // Blue
+        PromptContextColor: "#9a6700", // Yellow
+        PromptCosmosAliasColor: "#bc4c00", // Orange
+        PromptBlobAliasColor: "#8250df", // Purple
+        TableHeaderColor: "#0969da",   // Blue
+        TableBorderColor: "#d0d7de",   // Gray
+        ErrorColor: "#cf222e",         // Red
+        WarningColor: "#9a6700",       // Yellow
+        SuccessColor: "#1a7f37",       // Green
+        DimColor: "#6e7781",           // Gray
+        JsonKeyColor: "#0969da",       // Blue
+        JsonStringColor: "#0a3069",    // Dark blue
+        JsonNumberColor: "#8250df",    // Purple
+        JsonBooleanColor: "#9a6700",   // Yellow
+        JsonNullColor: "#6e7781",      // Gray
+        BannerColor: "#0969da");       // Blue
+
+    // ========== Xcode ==========
+
+    /// <summary>Xcode Dark - Apple's dark theme.</summary>
+    public static ThemeConfig XcodeDark { get; } = new(
+        PromptColor: "#84dc7c",        // Green
+        PromptSessionColor: "#6bdfff", // Cyan
+        PromptContextColor: "#fef383", // Yellow
+        PromptCosmosAliasColor: "#ffa14f", // Orange
+        PromptBlobAliasColor: "#d9a6ff", // Purple
+        TableHeaderColor: "#4eb0cc",   // Blue
+        TableBorderColor: "#6c7986",   // Gray
+        ErrorColor: "#ff8170",         // Red
+        WarningColor: "#fef383",       // Yellow
+        SuccessColor: "#84dc7c",       // Green
+        DimColor: "#6c7986",           // Gray
+        JsonKeyColor: "#6bdfff",       // Cyan
+        JsonStringColor: "#ff8170",    // Salmon
+        JsonNumberColor: "#d9c97c",    // Light yellow
+        JsonBooleanColor: "#fef383",   // Yellow
+        JsonNullColor: "#6c7986",      // Gray
+        BannerColor: "#6bdfff");       // Cyan
+
+    /// <summary>Xcode Light - Apple's light theme.</summary>
+    public static ThemeConfig XcodeLight { get; } = new(
+        PromptColor: "#1d7d41",        // Green
+        PromptSessionColor: "#3e8087", // Teal
+        PromptContextColor: "#78492a", // Brown
+        PromptCosmosAliasColor: "#c33720", // Orange
+        PromptBlobAliasColor: "#ad3da4", // Purple
+        TableHeaderColor: "#0f68a0",   // Blue
+        TableBorderColor: "#c5c5c5",   // Gray
+        ErrorColor: "#c33720",         // Red
+        WarningColor: "#78492a",       // Brown
+        SuccessColor: "#1d7d41",       // Green
+        DimColor: "#8e8e93",           // Gray
+        JsonKeyColor: "#3e8087",       // Teal
+        JsonStringColor: "#c33720",    // Red
+        JsonNumberColor: "#1c00cf",    // Blue
+        JsonBooleanColor: "#ad3da4",   // Purple
+        JsonNullColor: "#8e8e93",      // Gray
+        BannerColor: "#0f68a0");       // Blue
+
+    // ========== TokyoNight ==========
+
+    /// <summary>TokyoNight Night - dark blue theme.</summary>
+    public static ThemeConfig TokyoNightNight { get; } = new(
+        PromptColor: "#9ece6a",        // Green
+        PromptSessionColor: "#7dcfff", // Cyan
+        PromptContextColor: "#e0af68", // Yellow
+        PromptCosmosAliasColor: "#ff9e64", // Orange
+        PromptBlobAliasColor: "#bb9af7", // Purple
+        TableHeaderColor: "#7aa2f7",   // Blue
+        TableBorderColor: "#565f89",   // Gray
+        ErrorColor: "#f7768e",         // Red
+        WarningColor: "#e0af68",       // Yellow
+        SuccessColor: "#9ece6a",       // Green
+        DimColor: "#565f89",           // Gray
+        JsonKeyColor: "#7aa2f7",       // Blue
+        JsonStringColor: "#9ece6a",    // Green
+        JsonNumberColor: "#ff9e64",    // Orange
+        JsonBooleanColor: "#e0af68",   // Yellow
+        JsonNullColor: "#565f89",      // Gray
+        BannerColor: "#7dcfff");       // Cyan
+
+    /// <summary>TokyoNight Storm - dark with lighter background.</summary>
+    public static ThemeConfig TokyoNightStorm { get; } = new(
+        PromptColor: "#9ece6a",        // Green
+        PromptSessionColor: "#7dcfff", // Cyan
+        PromptContextColor: "#e0af68", // Yellow
+        PromptCosmosAliasColor: "#ff9e64", // Orange
+        PromptBlobAliasColor: "#bb9af7", // Purple
+        TableHeaderColor: "#7aa2f7",   // Blue
+        TableBorderColor: "#545c7e",   // Gray
+        ErrorColor: "#f7768e",         // Red
+        WarningColor: "#e0af68",       // Yellow
+        SuccessColor: "#9ece6a",       // Green
+        DimColor: "#545c7e",           // Gray
+        JsonKeyColor: "#7aa2f7",       // Blue
+        JsonStringColor: "#9ece6a",    // Green
+        JsonNumberColor: "#ff9e64",    // Orange
+        JsonBooleanColor: "#e0af68",   // Yellow
+        JsonNullColor: "#545c7e",      // Gray
+        BannerColor: "#7dcfff");       // Cyan
+
+    /// <summary>TokyoNight Day - light variant.</summary>
+    public static ThemeConfig TokyoNightDay { get; } = new(
+        PromptColor: "#587539",        // Green
+        PromptSessionColor: "#007197", // Cyan
+        PromptContextColor: "#8c6c3e", // Yellow
+        PromptCosmosAliasColor: "#965027", // Orange
+        PromptBlobAliasColor: "#7847bd", // Purple
+        TableHeaderColor: "#2e7de9",   // Blue
+        TableBorderColor: "#9699a3",   // Gray
+        ErrorColor: "#f52a65",         // Red
+        WarningColor: "#8c6c3e",       // Yellow
+        SuccessColor: "#587539",       // Green
+        DimColor: "#9699a3",           // Gray
+        JsonKeyColor: "#2e7de9",       // Blue
+        JsonStringColor: "#587539",    // Green
+        JsonNumberColor: "#965027",    // Orange
+        JsonBooleanColor: "#8c6c3e",   // Yellow
+        JsonNullColor: "#9699a3",      // Gray
+        BannerColor: "#007197");       // Cyan
+
+    // ========== Nord ==========
+
+    /// <summary>Nord - arctic, north-bluish theme.</summary>
+    public static ThemeConfig Nord { get; } = new(
+        PromptColor: "#a3be8c",        // nord14 - Green
+        PromptSessionColor: "#88c0d0", // nord8 - Frost cyan
+        PromptContextColor: "#ebcb8b", // nord13 - Yellow
+        PromptCosmosAliasColor: "#d08770", // nord12 - Orange
+        PromptBlobAliasColor: "#b48ead", // nord15 - Purple
+        TableHeaderColor: "#81a1c1",   // nord9 - Frost blue
+        TableBorderColor: "#4c566a",   // nord3 - Dark gray
+        ErrorColor: "#bf616a",         // nord11 - Red
+        WarningColor: "#ebcb8b",       // nord13 - Yellow
+        SuccessColor: "#a3be8c",       // nord14 - Green
+        DimColor: "#4c566a",           // nord3
+        JsonKeyColor: "#81a1c1",       // nord9
+        JsonStringColor: "#a3be8c",    // nord14
+        JsonNumberColor: "#b48ead",    // nord15
+        JsonBooleanColor: "#ebcb8b",   // nord13
+        JsonNullColor: "#4c566a",      // nord3
+        BannerColor: "#88c0d0");       // nord8
+
+    // ========== VSCode ==========
+
+    /// <summary>VSCode Dark+ - Visual Studio Code's default dark theme.</summary>
+    public static ThemeConfig VSCodeDark { get; } = new(
+        PromptColor: "#6a9955",        // Green
+        PromptSessionColor: "#4ec9b0", // Teal
+        PromptContextColor: "#dcdcaa", // Yellow
+        PromptCosmosAliasColor: "#ce9178", // Orange
+        PromptBlobAliasColor: "#c586c0", // Purple
+        TableHeaderColor: "#569cd6",   // Blue
+        TableBorderColor: "#6e7681",   // Gray
+        ErrorColor: "#f14c4c",         // Red
+        WarningColor: "#dcdcaa",       // Yellow
+        SuccessColor: "#6a9955",       // Green
+        DimColor: "#6e7681",           // Gray
+        JsonKeyColor: "#9cdcfe",       // Light blue
+        JsonStringColor: "#ce9178",    // Orange
+        JsonNumberColor: "#b5cea8",    // Light green
+        JsonBooleanColor: "#569cd6",   // Blue
+        JsonNullColor: "#569cd6",      // Blue
+        BannerColor: "#4ec9b0");       // Teal
+
+    /// <summary>VSCode Light+ - Visual Studio Code's default light theme.</summary>
+    public static ThemeConfig VSCodeLight { get; } = new(
+        PromptColor: "#008000",        // Green
+        PromptSessionColor: "#267f99", // Teal
+        PromptContextColor: "#795e26", // Yellow
+        PromptCosmosAliasColor: "#a31515", // Red
+        PromptBlobAliasColor: "#af00db", // Purple
+        TableHeaderColor: "#0000ff",   // Blue
+        TableBorderColor: "#c5c5c5",   // Gray
+        ErrorColor: "#cd3131",         // Red
+        WarningColor: "#795e26",       // Yellow
+        SuccessColor: "#008000",       // Green
+        DimColor: "#6e7681",           // Gray
+        JsonKeyColor: "#0451a5",       // Blue
+        JsonStringColor: "#a31515",    // Red
+        JsonNumberColor: "#098658",    // Green
+        JsonBooleanColor: "#0000ff",   // Blue
+        JsonNullColor: "#0000ff",      // Blue
+        BannerColor: "#267f99");       // Teal
+
+    // ========== Material ==========
+
+    /// <summary>Material Darker - Material Design dark theme.</summary>
+    public static ThemeConfig MaterialDarker { get; } = new(
+        PromptColor: "#c3e88d",        // Green
+        PromptSessionColor: "#89ddff", // Cyan
+        PromptContextColor: "#ffcb6b", // Yellow
+        PromptCosmosAliasColor: "#f78c6c", // Orange
+        PromptBlobAliasColor: "#c792ea", // Purple
+        TableHeaderColor: "#82aaff",   // Blue
+        TableBorderColor: "#545454",   // Gray
+        ErrorColor: "#f07178",         // Red
+        WarningColor: "#ffcb6b",       // Yellow
+        SuccessColor: "#c3e88d",       // Green
+        DimColor: "#545454",           // Gray
+        JsonKeyColor: "#82aaff",       // Blue
+        JsonStringColor: "#c3e88d",    // Green
+        JsonNumberColor: "#f78c6c",    // Orange
+        JsonBooleanColor: "#ffcb6b",   // Yellow
+        JsonNullColor: "#545454",      // Gray
+        BannerColor: "#89ddff");       // Cyan
+
+    /// <summary>Material Ocean - Material Design ocean variant.</summary>
+    public static ThemeConfig MaterialOcean { get; } = new(
+        PromptColor: "#c3e88d",        // Green
+        PromptSessionColor: "#89ddff", // Cyan
+        PromptContextColor: "#ffcb6b", // Yellow
+        PromptCosmosAliasColor: "#f78c6c", // Orange
+        PromptBlobAliasColor: "#c792ea", // Purple
+        TableHeaderColor: "#82aaff",   // Blue
+        TableBorderColor: "#464b5d",   // Gray
+        ErrorColor: "#f07178",         // Red
+        WarningColor: "#ffcb6b",       // Yellow
+        SuccessColor: "#c3e88d",       // Green
+        DimColor: "#464b5d",           // Gray
+        JsonKeyColor: "#82aaff",       // Blue
+        JsonStringColor: "#c3e88d",    // Green
+        JsonNumberColor: "#f78c6c",    // Orange
+        JsonBooleanColor: "#ffcb6b",   // Yellow
+        JsonNullColor: "#464b5d",      // Gray
+        BannerColor: "#89ddff");       // Cyan
+
+    /// <summary>Material Palenight - Material Design palenight variant.</summary>
+    public static ThemeConfig MaterialPalenight { get; } = new(
+        PromptColor: "#c3e88d",        // Green
+        PromptSessionColor: "#89ddff", // Cyan
+        PromptContextColor: "#ffcb6b", // Yellow
+        PromptCosmosAliasColor: "#f78c6c", // Orange
+        PromptBlobAliasColor: "#c792ea", // Purple
+        TableHeaderColor: "#82aaff",   // Blue
+        TableBorderColor: "#676e95",   // Gray
+        ErrorColor: "#f07178",         // Red
+        WarningColor: "#ffcb6b",       // Yellow
+        SuccessColor: "#c3e88d",       // Green
+        DimColor: "#676e95",           // Gray
+        JsonKeyColor: "#82aaff",       // Blue
+        JsonStringColor: "#c3e88d",    // Green
+        JsonNumberColor: "#f78c6c",    // Orange
+        JsonBooleanColor: "#ffcb6b",   // Yellow
+        JsonNullColor: "#676e95",      // Gray
+        BannerColor: "#89ddff");       // Cyan
+
+    // ========== Solarized ==========
+
+    /// <summary>Solarized Dark - Ethan Schoonover's dark theme.</summary>
+    public static ThemeConfig SolarizedDark { get; } = new(
+        PromptColor: "#859900",        // Green
+        PromptSessionColor: "#2aa198", // Cyan
+        PromptContextColor: "#b58900", // Yellow
+        PromptCosmosAliasColor: "#cb4b16", // Orange
+        PromptBlobAliasColor: "#6c71c4", // Violet
+        TableHeaderColor: "#268bd2",   // Blue
+        TableBorderColor: "#586e75",   // Gray
+        ErrorColor: "#dc322f",         // Red
+        WarningColor: "#b58900",       // Yellow
+        SuccessColor: "#859900",       // Green
+        DimColor: "#586e75",           // Gray
+        JsonKeyColor: "#268bd2",       // Blue
+        JsonStringColor: "#2aa198",    // Cyan
+        JsonNumberColor: "#d33682",    // Magenta
+        JsonBooleanColor: "#b58900",   // Yellow
+        JsonNullColor: "#586e75",      // Gray
+        BannerColor: "#2aa198");       // Cyan
+
+    /// <summary>Solarized Light - Ethan Schoonover's light theme.</summary>
+    public static ThemeConfig SolarizedLight { get; } = new(
+        PromptColor: "#859900",        // Green
+        PromptSessionColor: "#2aa198", // Cyan
+        PromptContextColor: "#b58900", // Yellow
+        PromptCosmosAliasColor: "#cb4b16", // Orange
+        PromptBlobAliasColor: "#6c71c4", // Violet
+        TableHeaderColor: "#268bd2",   // Blue
+        TableBorderColor: "#93a1a1",   // Gray
+        ErrorColor: "#dc322f",         // Red
+        WarningColor: "#b58900",       // Yellow
+        SuccessColor: "#859900",       // Green
+        DimColor: "#93a1a1",           // Gray
+        JsonKeyColor: "#268bd2",       // Blue
+        JsonStringColor: "#2aa198",    // Cyan
+        JsonNumberColor: "#d33682",    // Magenta
+        JsonBooleanColor: "#b58900",   // Yellow
+        JsonNullColor: "#93a1a1",      // Gray
+        BannerColor: "#2aa198");       // Cyan
+
+    // ========== Preset Dictionary & Helper Methods ==========
+    // NOTE: This must be declared AFTER all theme properties to ensure proper initialization order.
+
+    /// <summary>
+    /// Gets a dictionary of all available preset themes.
+    /// </summary>
+    public static IReadOnlyDictionary<string, ThemeConfig> All { get; } = new Dictionary<string, ThemeConfig>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["default"] = ThemeConfig.Default,
+
+        // Catppuccin - https://catppuccin.com
+        ["catppuccin-mocha"] = CatppuccinMocha,
+        ["catppuccin-macchiato"] = CatppuccinMacchiato,
+        ["catppuccin-frappe"] = CatppuccinFrappe,
+        ["catppuccin-latte"] = CatppuccinLatte,
+
+        // Dracula - https://draculatheme.com
+        ["dracula"] = Dracula,
+
+        // One Dark - Atom
+        ["one-dark"] = OneDark,
+
+        // Gruvbox - https://github.com/morhetz/gruvbox
+        ["gruvbox-dark"] = GruvboxDark,
+        ["gruvbox-light"] = GruvboxLight,
+
+        // Ayu - https://github.com/ayu-theme
+        ["ayu-dark"] = AyuDark,
+        ["ayu-mirage"] = AyuMirage,
+        ["ayu-light"] = AyuLight,
+
+        // GitHub
+        ["github-dark"] = GitHubDark,
+        ["github-light"] = GitHubLight,
+
+        // Xcode
+        ["xcode-dark"] = XcodeDark,
+        ["xcode-light"] = XcodeLight,
+
+        // TokyoNight - https://github.com/folke/tokyonight.nvim
+        ["tokyonight-night"] = TokyoNightNight,
+        ["tokyonight-storm"] = TokyoNightStorm,
+        ["tokyonight-day"] = TokyoNightDay,
+
+        // Nord - https://www.nordtheme.com
+        ["nord"] = Nord,
+
+        // VSCode
+        ["vscode-dark"] = VSCodeDark,
+        ["vscode-light"] = VSCodeLight,
+
+        // Material - https://material-theme.site
+        ["material-darker"] = MaterialDarker,
+        ["material-ocean"] = MaterialOcean,
+        ["material-palenight"] = MaterialPalenight,
+
+        // Solarized - https://ethanschoonover.com/solarized
+        ["solarized-dark"] = SolarizedDark,
+        ["solarized-light"] = SolarizedLight,
+    };
+
+    /// <summary>
+    /// Gets a preset theme by name, or null if not found.
+    /// </summary>
+    public static ThemeConfig? GetPreset(string name) =>
+        All.TryGetValue(name, out var theme) ? theme : null;
+
+    /// <summary>
+    /// Gets all available preset theme names.
+    /// </summary>
+    public static IEnumerable<string> GetPresetNames() => All.Keys;
+}

--- a/src/NimbusStation.Tests/Cli/Commands/AuthCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/AuthCommandTests.cs
@@ -10,6 +10,7 @@ public sealed class AuthCommandTests
 {
     private readonly StubSessionStateManager _sessionStateManager;
     private readonly MockAzureAuthService _authService;
+    private readonly StubConfigurationService _configurationService;
     private readonly AuthCommand _command;
     private readonly CaptureOutputWriter _outputWriter;
 
@@ -17,7 +18,8 @@ public sealed class AuthCommandTests
     {
         _sessionStateManager = new StubSessionStateManager();
         _authService = new MockAzureAuthService();
-        _command = new AuthCommand(_authService);
+        _configurationService = new StubConfigurationService();
+        _command = new AuthCommand(_authService, _configurationService);
         _outputWriter = new CaptureOutputWriter();
     }
 

--- a/src/NimbusStation.Tests/Cli/Commands/ThemeCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/ThemeCommandTests.cs
@@ -1,0 +1,232 @@
+using NimbusStation.Cli.Commands;
+using NimbusStation.Core.Commands;
+using NimbusStation.Infrastructure.Configuration;
+using NimbusStation.Infrastructure.Output;
+using NimbusStation.Tests.Fixtures;
+
+namespace NimbusStation.Tests.Cli.Commands;
+
+public sealed class ThemeCommandTests
+{
+    private readonly StubSessionStateManager _sessionStateManager;
+    private readonly StubConfigurationService _configurationService;
+    private readonly ThemeCommand _command;
+    private readonly CaptureOutputWriter _outputWriter;
+
+    public ThemeCommandTests()
+    {
+        _sessionStateManager = new StubSessionStateManager();
+        _configurationService = new StubConfigurationService();
+        _command = new ThemeCommand(_configurationService);
+        _outputWriter = new CaptureOutputWriter();
+    }
+
+    [Fact]
+    public void Name_ReturnsTheme()
+    {
+        Assert.Equal("theme", _command.Name);
+    }
+
+    [Fact]
+    public void Subcommands_ContainsExpectedValues()
+    {
+        Assert.Contains("list", _command.Subcommands);
+        Assert.Contains("ls", _command.Subcommands);
+        Assert.Contains("preview", _command.Subcommands);
+        Assert.Contains("current", _command.Subcommands);
+        Assert.Contains("presets", _command.Subcommands);
+    }
+
+    [Fact]
+    public void Usage_ReturnsExpectedFormat()
+    {
+        Assert.Contains("theme", _command.Usage);
+        Assert.Contains("list", _command.Usage);
+        Assert.Contains("preview", _command.Usage);
+        Assert.Contains("current", _command.Usage);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoArgs_ShowsCurrent()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync([], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<ThemeConfig>(result.Data);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Current_ReturnsSuccess()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["current"], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<ThemeConfig>(result.Data);
+        Assert.Contains("Current Theme Configuration", _outputWriter.GetOutput());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_ReturnsAllPresets()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["list"], context);
+
+        Assert.True(result.Success);
+        var presets = Assert.IsType<List<string>>(result.Data);
+        Assert.True(presets.Count >= 24); // We have 24 presets
+        Assert.Contains("default", presets);
+        Assert.Contains("catppuccin-mocha", presets);
+        Assert.Contains("dracula", presets);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Ls_ReturnsAllPresets()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["ls"], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<List<string>>(result.Data);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Presets_ReturnsAllPresets()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["presets"], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<List<string>>(result.Data);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_OutputContainsThemes()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        await _command.ExecuteAsync(["list"], context);
+
+        Assert.Contains("theme(s) available", _outputWriter.GetOutput());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_ValidTheme_ReturnsSuccess()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["preview", "dracula"], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<ThemeConfig>(result.Data);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_ValidTheme_ShowsPreview()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        await _command.ExecuteAsync(["preview", "catppuccin-mocha"], context);
+
+        Assert.Contains("Preview: catppuccin-mocha", _outputWriter.GetOutput());
+        Assert.Contains("Sample prompt:", _outputWriter.GetOutput());
+        Assert.Contains("Sample messages:", _outputWriter.GetOutput());
+        Assert.Contains("Sample JSON:", _outputWriter.GetOutput());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_InvalidTheme_ReturnsError()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["preview", "nonexistent-theme"], context);
+
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_NoThemeName_ReturnsError()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["preview"], context);
+
+        Assert.False(result.Success);
+        Assert.Contains("Usage", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownSubcommand_ReturnsError()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["unknown"], context);
+
+        Assert.False(result.Success);
+        Assert.Contains("Unknown subcommand", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_CaseInsensitive_ReturnsSuccess()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["preview", "DRACULA"], context);
+
+        Assert.True(result.Success);
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("catppuccin-mocha")]
+    [InlineData("catppuccin-macchiato")]
+    [InlineData("catppuccin-frappe")]
+    [InlineData("catppuccin-latte")]
+    [InlineData("dracula")]
+    [InlineData("one-dark")]
+    [InlineData("gruvbox-dark")]
+    [InlineData("gruvbox-light")]
+    [InlineData("nord")]
+    [InlineData("solarized-dark")]
+    [InlineData("solarized-light")]
+    public async Task ExecuteAsync_Preview_AllMajorThemes_ReturnsSuccess(string themeName)
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        var result = await _command.ExecuteAsync(["preview", themeName], context);
+
+        Assert.True(result.Success);
+        Assert.IsType<ThemeConfig>(result.Data);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Current_ShowsConfigHint()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        await _command.ExecuteAsync(["current"], context);
+
+        // The config hint is written via WriteLine(), not part of the table
+        Assert.Contains("config.toml", _outputWriter.GetOutput());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Preview_ShowsConfigHint()
+    {
+        var context = new CommandContext(_sessionStateManager, _outputWriter);
+
+        await _command.ExecuteAsync(["preview", "nord"], context);
+
+        // The config hint is written via WriteLine()
+        Assert.Contains("config.toml", _outputWriter.GetOutput());
+        Assert.Contains("theme", _outputWriter.GetOutput());
+        Assert.Contains("preset", _outputWriter.GetOutput());
+    }
+}

--- a/src/NimbusStation.Tests/Cli/Output/SpectreColorHelperTests.cs
+++ b/src/NimbusStation.Tests/Cli/Output/SpectreColorHelperTests.cs
@@ -1,0 +1,159 @@
+using NimbusStation.Cli.Output;
+using Spectre.Console;
+
+namespace NimbusStation.Tests.Cli.Output;
+
+public sealed class SpectreColorHelperTests
+{
+    [Theory]
+    [InlineData("#000000", 0, 0, 0)]
+    [InlineData("#FFFFFF", 255, 255, 255)]
+    [InlineData("#FF0000", 255, 0, 0)]
+    [InlineData("#00FF00", 0, 255, 0)]
+    [InlineData("#0000FF", 0, 0, 255)]
+    [InlineData("#50FA7B", 80, 250, 123)]
+    [InlineData("#abcdef", 171, 205, 239)]
+    public void TryParseColor_ValidSixDigitHex_ReturnsCorrectColor(string input, byte r, byte g, byte b)
+    {
+        var result = SpectreColorHelper.TryParseColor(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(r, result.Value.R);
+        Assert.Equal(g, result.Value.G);
+        Assert.Equal(b, result.Value.B);
+    }
+
+    [Theory]
+    [InlineData("#000", 0, 0, 0)]
+    [InlineData("#FFF", 255, 255, 255)]
+    [InlineData("#F00", 255, 0, 0)]
+    [InlineData("#0F0", 0, 255, 0)]
+    [InlineData("#00F", 0, 0, 255)]
+    [InlineData("#abc", 170, 187, 204)]
+    public void TryParseColor_ValidThreeDigitHex_ExpandsAndReturnsCorrectColor(string input, byte r, byte g, byte b)
+    {
+        var result = SpectreColorHelper.TryParseColor(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(r, result.Value.R);
+        Assert.Equal(g, result.Value.G);
+        Assert.Equal(b, result.Value.B);
+    }
+
+    [Theory]
+    [InlineData("rgb(0,0,0)", 0, 0, 0)]
+    [InlineData("rgb(255,255,255)", 255, 255, 255)]
+    [InlineData("rgb(80,250,123)", 80, 250, 123)]
+    [InlineData("RGB(100,150,200)", 100, 150, 200)]
+    [InlineData("rgb( 50 , 100 , 150 )", 50, 100, 150)]
+    public void TryParseColor_ValidRgb_ReturnsCorrectColor(string input, byte r, byte g, byte b)
+    {
+        var result = SpectreColorHelper.TryParseColor(input);
+
+        Assert.NotNull(result);
+        Assert.Equal(r, result.Value.R);
+        Assert.Equal(g, result.Value.G);
+        Assert.Equal(b, result.Value.B);
+    }
+
+    [Fact]
+    public void TryParseColor_NamedColorGreen_ReturnsGreen()
+    {
+        var result = SpectreColorHelper.TryParseColor("green");
+
+        Assert.NotNull(result);
+        Assert.Equal(Color.Green, result.Value);
+    }
+
+    [Fact]
+    public void TryParseColor_NamedColorRed_ReturnsRed()
+    {
+        var result = SpectreColorHelper.TryParseColor("red");
+
+        Assert.NotNull(result);
+        Assert.Equal(Color.Red, result.Value);
+    }
+
+    [Fact]
+    public void TryParseColor_NamedColorCaseInsensitive_ReturnsColor()
+    {
+        var lower = SpectreColorHelper.TryParseColor("blue");
+        var upper = SpectreColorHelper.TryParseColor("BLUE");
+        var mixed = SpectreColorHelper.TryParseColor("Blue");
+
+        Assert.NotNull(lower);
+        Assert.NotNull(upper);
+        Assert.NotNull(mixed);
+        Assert.Equal(lower, upper);
+        Assert.Equal(lower, mixed);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void TryParseColor_EmptyOrWhitespace_ReturnsNull(string? input)
+    {
+        var result = SpectreColorHelper.TryParseColor(input!);
+
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("#")]
+    [InlineData("#12")]
+    [InlineData("#1234")]
+    [InlineData("#GGGGGG")]
+    [InlineData("rgb(256,0,0)")]
+    [InlineData("rgb(0,0)")]
+    [InlineData("notacolor")]
+    [InlineData("invalid123")]
+    public void TryParseColor_InvalidInput_ReturnsNull(string input)
+    {
+        var result = SpectreColorHelper.TryParseColor(input);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseColorOrDefault_ValidColor_ReturnsColor()
+    {
+        var result = SpectreColorHelper.ParseColorOrDefault("#FF0000", Color.White);
+
+        Assert.Equal(255, result.R);
+        Assert.Equal(0, result.G);
+        Assert.Equal(0, result.B);
+    }
+
+    [Fact]
+    public void ParseColorOrDefault_InvalidColor_ReturnsFallback()
+    {
+        var fallback = Color.Yellow;
+        var result = SpectreColorHelper.ParseColorOrDefault("invalid", fallback);
+
+        Assert.Equal(fallback, result);
+    }
+
+    [Fact]
+    public void ParseColorOrDefault_EmptyString_ReturnsFallback()
+    {
+        var fallback = Color.Cyan;
+        var result = SpectreColorHelper.ParseColorOrDefault("", fallback);
+
+        Assert.Equal(fallback, result);
+    }
+
+    [Fact]
+    public void IsValidColor_DelegatesToColorFormatValidator()
+    {
+        // Valid colors
+        Assert.True(SpectreColorHelper.IsValidColor("#FF0000"));
+        Assert.True(SpectreColorHelper.IsValidColor("rgb(255,0,0)"));
+        Assert.True(SpectreColorHelper.IsValidColor("green"));
+
+        // Invalid colors
+        Assert.False(SpectreColorHelper.IsValidColor(""));
+        Assert.False(SpectreColorHelper.IsValidColor("#GGG"));
+        Assert.False(SpectreColorHelper.IsValidColor("[red]"));
+    }
+}

--- a/src/NimbusStation.Tests/Infrastructure/Configuration/ColorFormatValidatorTests.cs
+++ b/src/NimbusStation.Tests/Infrastructure/Configuration/ColorFormatValidatorTests.cs
@@ -1,0 +1,120 @@
+using NimbusStation.Infrastructure.Configuration;
+
+namespace NimbusStation.Tests.Infrastructure.Configuration;
+
+public sealed class ColorFormatValidatorTests
+{
+    [Theory]
+    [InlineData("#000000")]
+    [InlineData("#FFFFFF")]
+    [InlineData("#50FA7B")]
+    [InlineData("#abcdef")]
+    [InlineData("#ABC123")]
+    public void IsValid_ValidSixDigitHex_ReturnsTrue(string color)
+    {
+        Assert.True(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("#000")]
+    [InlineData("#FFF")]
+    [InlineData("#abc")]
+    [InlineData("#F0A")]
+    public void IsValid_ValidThreeDigitHex_ReturnsTrue(string color)
+    {
+        Assert.True(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("#")]
+    [InlineData("#1")]
+    [InlineData("#12")]
+    [InlineData("#1234")]
+    [InlineData("#12345")]
+    [InlineData("#1234567")]
+    [InlineData("#GGGGGG")]
+    [InlineData("#XYZ")]
+    [InlineData("# 000000")]
+    public void IsValid_InvalidHex_ReturnsFalse(string color)
+    {
+        Assert.False(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("rgb(0,0,0)")]
+    [InlineData("rgb(255,255,255)")]
+    [InlineData("rgb(80,250,123)")]
+    [InlineData("RGB(100,150,200)")]
+    [InlineData("Rgb(0, 0, 0)")]
+    [InlineData("rgb( 100 , 150 , 200 )")]
+    public void IsValid_ValidRgb_ReturnsTrue(string color)
+    {
+        Assert.True(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("rgb(256,0,0)")]
+    [InlineData("rgb(-1,0,0)")]
+    [InlineData("rgb(0,0)")]
+    [InlineData("rgb(0,0,0,0)")]
+    [InlineData("rgb()")]
+    [InlineData("rgb(a,b,c)")]
+    [InlineData("rgb(0,0,0")]
+    [InlineData("rgb0,0,0)")]
+    public void IsValid_InvalidRgb_ReturnsFalse(string color)
+    {
+        Assert.False(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("green")]
+    [InlineData("red")]
+    [InlineData("blue")]
+    [InlineData("cyan")]
+    [InlineData("magenta")]
+    [InlineData("yellow")]
+    [InlineData("white")]
+    [InlineData("black")]
+    [InlineData("grey")]
+    [InlineData("orange1")]
+    [InlineData("cyan1")]
+    [InlineData("Green")]
+    [InlineData("GREEN")]
+    public void IsValid_ValidNamedColor_ReturnsTrue(string color)
+    {
+        Assert.True(ColorFormatValidator.IsValid(color));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void IsValid_EmptyOrWhitespace_ReturnsFalse(string? color)
+    {
+        Assert.False(ColorFormatValidator.IsValid(color!));
+    }
+
+    [Theory]
+    [InlineData("green-dark")]
+    [InlineData("light_blue")]
+    [InlineData("red!")]
+    [InlineData("color with space")]
+    [InlineData("[red]")]
+    [InlineData("red[/]")]
+    [InlineData("[[red]]")]
+    public void IsValid_InvalidNamedColor_ReturnsFalse(string color)
+    {
+        Assert.False(ColorFormatValidator.IsValid(color));
+    }
+
+    [Fact]
+    public void IsValid_MarkupInjectionAttempts_ReturnsFalse()
+    {
+        // Verify that characters that could cause markup injection are rejected
+        Assert.False(ColorFormatValidator.IsValid("[red]"));
+        Assert.False(ColorFormatValidator.IsValid("red]"));
+        Assert.False(ColorFormatValidator.IsValid("["));
+        Assert.False(ColorFormatValidator.IsValid("]"));
+        Assert.False(ColorFormatValidator.IsValid("color[bold]"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable UI theming system allowing users to customize terminal colors via `~/.config/nimbus/config.toml`
- Include 24 preset themes (Catppuccin, Dracula, One Dark, Gruvbox, Ayu, GitHub, Xcode, TokyoNight, Nord, VSCode, Material, Solarized)
- Add `theme` command with `list`, `preview`, and `current` subcommands for theme discovery and preview

## Changes
- **ThemeConfig**: Expanded from 3 to 17 color properties covering prompt, tables, messages, and JSON highlighting
- **ThemePresets**: 24 curated color schemes from popular terminal/editor themes
- **ColorFormatValidator**: Validates hex (`#RRGGBB`), rgb (`rgb(R,G,B)`), and named color formats
- **SpectreColorHelper**: Parses color strings into Spectre.Console.Color objects
- **BannerPrinter**: Themed startup banner
- **ThemeCommand**: New command for listing, previewing, and viewing current theme
- **ConfigurationService**: Updated to parse `preset` property with individual color overrides
- **All commands**: Replaced hardcoded colors with theme properties

## Configuration Example
```toml
[theme]
preset = "catppuccin-mocha"
error_color = "#FF0000"  # optional override
```

## Testing
- 29 new ThemeCommandTests
- All 597 tests pass

Closes #11