### PR TITLE
refactor: Commands declare their own aliases and pipe behavior

### DIFF
--- a/src/NimbusStation.Cli/Commands/AliasCommand.cs
+++ b/src/NimbusStation.Cli/Commands/AliasCommand.cs
@@ -15,10 +15,10 @@ public sealed class AliasCommand : ICommand
     private readonly IAliasResolver _aliasResolver;
     private readonly IConfigurationService _configurationService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
+    private static readonly HashSet<string> _subcommands =
+    [
         "list", "ls", "show", "add", "remove", "rm", "test"
-    };
+    ];
 
     /// <inheritdoc/>
     public string Name => "alias";

--- a/src/NimbusStation.Cli/Commands/AuthCommand.cs
+++ b/src/NimbusStation.Cli/Commands/AuthCommand.cs
@@ -13,10 +13,7 @@ public sealed class AuthCommand : ICommand
     private readonly IAzureAuthService _authService;
     private readonly IConfigurationService _configurationService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "status", "login"
-    };
+    private static readonly HashSet<string> _subcommands = ["status", "login"];
 
     /// <inheritdoc/>
     public string Name => "auth";

--- a/src/NimbusStation.Cli/Commands/BlobCommand.cs
+++ b/src/NimbusStation.Cli/Commands/BlobCommand.cs
@@ -18,10 +18,7 @@ public sealed class BlobCommand : ICommand
     private readonly IConfigurationService _configurationService;
     private readonly ISessionService _sessionService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "containers", "list", "get", "download"
-    };
+    private static readonly HashSet<string> _subcommands = ["containers", "list", "get", "download"];
 
     /// <inheritdoc/>
     public string Name => "blob";

--- a/src/NimbusStation.Cli/Commands/CosmosCommand.cs
+++ b/src/NimbusStation.Cli/Commands/CosmosCommand.cs
@@ -19,10 +19,7 @@ public sealed class CosmosCommand : ICommand
     private readonly IConfigurationService _configurationService;
     private readonly ISessionService _sessionService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "query"
-    };
+    private static readonly HashSet<string> _subcommands = ["query"];
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {

--- a/src/NimbusStation.Cli/Commands/ExitCommand.cs
+++ b/src/NimbusStation.Cli/Commands/ExitCommand.cs
@@ -20,6 +20,12 @@ public sealed class ExitCommand : ICommand
     public IReadOnlySet<string> Subcommands { get; } = new HashSet<string>();
 
     /// <inheritdoc/>
+    public IReadOnlySet<string> Aliases { get; } = new HashSet<string> { "quit", "q" };
+
+    /// <inheritdoc/>
+    public bool CanBePiped => false;
+
+    /// <inheritdoc/>
     public Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default) =>
         Task.FromResult(CommandResult.Exit());
 }

--- a/src/NimbusStation.Cli/Commands/HelpCommand.cs
+++ b/src/NimbusStation.Cli/Commands/HelpCommand.cs
@@ -25,6 +25,12 @@ public sealed class HelpCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands.Value;
 
+    /// <inheritdoc/>
+    public IReadOnlySet<string> Aliases { get; } = new HashSet<string> { "?" };
+
+    /// <inheritdoc/>
+    public bool CanBePiped => false;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="HelpCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/SessionCommand.cs
+++ b/src/NimbusStation.Cli/Commands/SessionCommand.cs
@@ -15,10 +15,10 @@ public sealed class SessionCommand : ICommand
     private readonly ISessionStateManager _sessionStateManager;
     private readonly IConfigurationService _configurationService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
+    private static readonly HashSet<string> _subcommands =
+    [
         "start", "list", "ls", "leave", "resume", "delete", "rm", "status"
-    };
+    ];
 
     /// <inheritdoc/>
     public string Name => "session";

--- a/src/NimbusStation.Cli/Commands/ThemeCommand.cs
+++ b/src/NimbusStation.Cli/Commands/ThemeCommand.cs
@@ -12,10 +12,7 @@ public sealed class ThemeCommand : ICommand
 {
     private readonly IConfigurationService _configurationService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "list", "ls", "preview", "current", "presets"
-    };
+    private static readonly HashSet<string> _subcommands = ["list", "ls", "preview", "current", "presets"];
 
     /// <inheritdoc/>
     public string Name => "theme";

--- a/src/NimbusStation.Cli/Commands/UseCommand.cs
+++ b/src/NimbusStation.Cli/Commands/UseCommand.cs
@@ -13,10 +13,7 @@ public sealed class UseCommand : ICommand
     private readonly ISessionStateManager _sessionStateManager;
     private readonly IConfigurationService _configurationService;
 
-    private static readonly HashSet<string> _subcommands = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "cosmos", "blob", "storage", "clear"
-    };
+    private static readonly HashSet<string> _subcommands = ["cosmos", "blob", "storage", "clear"];
 
     /// <inheritdoc/>
     public string Name => "use";

--- a/src/NimbusStation.Cli/Program.cs
+++ b/src/NimbusStation.Cli/Program.cs
@@ -118,10 +118,7 @@ public static class Program
             registry.Register(sp.GetRequiredService<CosmosCommand>());
             registry.Register(sp.GetRequiredService<BlobCommand>());
             registry.Register(sp.GetRequiredService<HelpCommand>());
-            registry.RegisterAlias("?", "help");
             registry.Register(sp.GetRequiredService<ExitCommand>());
-            registry.RegisterAlias("quit", "exit");
-            registry.RegisterAlias("q", "exit");
             return registry;
         });
 

--- a/src/NimbusStation.Core/Commands/ICommand.cs
+++ b/src/NimbusStation.Core/Commands/ICommand.cs
@@ -27,6 +27,18 @@ public interface ICommand
     IReadOnlySet<string> Subcommands => new HashSet<string>();
 
     /// <summary>
+    /// Gets the command aliases (alternative names for the command).
+    /// Returns an empty set if the command has no aliases.
+    /// </summary>
+    IReadOnlySet<string> Aliases => new HashSet<string>();
+
+    /// <summary>
+    /// Gets whether this command's output can be piped to external processes.
+    /// REPL-control commands (exit, help) should return false.
+    /// </summary>
+    bool CanBePiped => true;
+
+    /// <summary>
     /// Executes the command with the given arguments.
     /// </summary>
     /// <param name="args">The arguments passed to the command (excluding the command name itself).</param>

--- a/src/NimbusStation.Tests/Cli/Commands/ExitCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/ExitCommandTests.cs
@@ -71,4 +71,15 @@ public sealed class ExitCommandTests
     {
         Assert.Empty(_command.Subcommands);
     }
+
+    [Fact]
+    public void Aliases_ContainsQuitAndQ()
+    {
+        Assert.Contains("quit", _command.Aliases);
+        Assert.Contains("q", _command.Aliases);
+        Assert.Equal(2, _command.Aliases.Count);
+    }
+
+    [Fact]
+    public void CanBePiped_ReturnsFalse() => Assert.False(_command.CanBePiped);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/HelpCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/HelpCommandTests.cs
@@ -101,6 +101,16 @@ public sealed class HelpCommandTests
         Assert.Contains("test", subcommands);
     }
 
+    [Fact]
+    public void Aliases_ContainsQuestionMark()
+    {
+        Assert.Contains("?", _command.Aliases);
+        Assert.Single(_command.Aliases);
+    }
+
+    [Fact]
+    public void CanBePiped_ReturnsFalse() => Assert.False(_command.CanBePiped);
+
     private sealed class TestCommand : ICommand
     {
         public string Name => "test";


### PR DESCRIPTION
## Summary

Refactors `ICommand` interface so commands declare their own aliases and pipe behavior, eliminating scattered metadata in `Program.cs` and hardcoded checks in `ReplLoop.cs`.

- Commands now declare `Aliases` and `CanBePiped` properties
- `CommandRegistry.Register()` auto-registers aliases with conflict detection
- Commands and aliases are now **case-sensitive** (Unix convention)
- Removes ~15 lines of duplicated alias logic from `ReplLoop`

## Changes

| File | Changes |
|------|---------|
| `ICommand.cs` | Add `Aliases` and `CanBePiped` properties with defaults |
| `ExitCommand.cs` | Declare aliases `{"quit", "q"}`, `CanBePiped => false` |
| `HelpCommand.cs` | Declare alias `{"?"}`, `CanBePiped => false` |
| `CommandRegistry.cs` | Case-sensitive, auto-register aliases, throw on conflicts |
| `Program.cs` | Remove 3 manual `RegisterAlias()` calls |
| `ReplLoop.cs` | Replace hardcoded `IsExitCommand`/`IsHelpCommand` with `CanBePiped` |
| 7 command files | Remove `StringComparer.OrdinalIgnoreCase` from subcommands |
| 3 test files | Add/update tests for new behavior |

## Breaking Changes

- Commands and aliases are now **case-sensitive** (e.g., `Exit` no longer works, must use `exit`)
- This follows Unix CLI conventions (git, npm, gh, kubectl are all case-sensitive)
- The existing `CommandSuggester` will suggest corrections for typos

Closes #44