### PR TITLE
Add --help/-h flag to all commands

### DIFF
--- a/src/NimbusStation.Cli/Commands/AliasCommand.cs
+++ b/src/NimbusStation.Cli/Commands/AliasCommand.cs
@@ -32,6 +32,26 @@ public sealed class AliasCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("list, ls", "List all defined aliases"),
+            new("show <name>", "Show alias expansion details"),
+            new("add <name> \"<expansion>\"", "Define a new alias"),
+            new("remove, rm <name>", "Remove an alias"),
+            new("test <name> [args...]", "Preview alias expansion without executing")
+        ],
+        Examples =
+        [
+            new("alias add q \"cosmos query\"", "Create a shortcut for cosmos query"),
+            new("alias test q \"SELECT * FROM c\"", "Preview what 'q' expands to"),
+            new("alias list", "Show all aliases")
+        ],
+        Notes = "Aliases support positional parameters ({0}, {1}) and built-in variables ({ticket}, {today})."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AliasCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/AuthCommand.cs
+++ b/src/NimbusStation.Cli/Commands/AuthCommand.cs
@@ -27,6 +27,22 @@ public sealed class AuthCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("status", "Show current authentication status"),
+            new("login", "Authenticate with Azure via browser")
+        ],
+        Examples =
+        [
+            new("auth status", "Check if authenticated"),
+            new("auth login", "Open browser to sign in")
+        ],
+        Notes = "Requires Azure CLI (az) to be installed."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AuthCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/BlobCommand.cs
+++ b/src/NimbusStation.Cli/Commands/BlobCommand.cs
@@ -33,6 +33,28 @@ public sealed class BlobCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("containers", "List containers in the active storage account"),
+            new("list [prefix]", "List blobs, optionally filtered by prefix"),
+            new("get <path>", "Output blob content to stdout"),
+            new("download <path>", "Download blob to session downloads directory"),
+            new("search [prefix]", "Interactive blob search")
+        ],
+        Examples =
+        [
+            new("blob containers", "List all containers"),
+            new("blob list logs/", "List blobs under the logs/ prefix"),
+            new("blob get config.json", "Print blob content to stdout"),
+            new("blob download data/export.csv", "Download blob to session directory"),
+            new("blob get data.json | jq '.items'", "Pipe blob content to jq")
+        ],
+        Notes = "Requires an active blob or storage context (use 'use blob <alias>' or 'use storage <alias>' first)."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BlobCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/BrowseCommand.cs
+++ b/src/NimbusStation.Cli/Commands/BrowseCommand.cs
@@ -27,6 +27,23 @@ public sealed class BrowseCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("cosmos", "Browse Cosmos DB aliases"),
+            new("blob", "Browse Blob Storage aliases"),
+            new("storage", "Browse Storage Account aliases")
+        ],
+        Examples =
+        [
+            new("browse cosmos", "Browse and inspect cosmos aliases"),
+            new("browse blob", "Browse and inspect blob aliases")
+        ],
+        Notes = "Read-only browsing — displays alias details without activating them."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BrowseCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/CosmosCommand.cs
+++ b/src/NimbusStation.Cli/Commands/CosmosCommand.cs
@@ -38,6 +38,26 @@ public sealed class CosmosCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("query \"<SQL>\"", "Execute a SQL query against the active container")
+        ],
+        Flags =
+        [
+            new("--max-items N", "Limit results returned (default: 100)")
+        ],
+        Examples =
+        [
+            new("cosmos query \"SELECT * FROM c\"", "Query all documents"),
+            new("cosmos query \"SELECT * FROM c WHERE c.id = 'abc'\"", "Query with filter"),
+            new("cosmos query \"SELECT * FROM c\" --max-items 10", "Query with limit")
+        ],
+        Notes = "Requires an active cosmos context (use 'use cosmos <alias>' first). Results are saved to the session queries directory."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/ExitCommand.cs
+++ b/src/NimbusStation.Cli/Commands/ExitCommand.cs
@@ -26,6 +26,16 @@ public sealed class ExitCommand : ICommand
     public bool CanBePiped => false;
 
     /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Examples =
+        [
+            new("exit", "Exit the REPL")
+        ],
+        Notes = "Aliases: quit, q"
+    };
+
+    /// <inheritdoc/>
     public Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default) =>
         Task.FromResult(CommandResult.Exit());
 }

--- a/src/NimbusStation.Cli/Commands/HelpCommand.cs
+++ b/src/NimbusStation.Cli/Commands/HelpCommand.cs
@@ -1,3 +1,4 @@
+using NimbusStation.Cli.Output;
 using NimbusStation.Core.Commands;
 using NimbusStation.Infrastructure.Configuration;
 using Spectre.Console;
@@ -31,6 +32,16 @@ public sealed class HelpCommand : ICommand
     /// <inheritdoc/>
     public bool CanBePiped => false;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Examples =
+        [
+            new("help", "Show all available commands"),
+            new("help session", "Show detailed help for the session command")
+        ]
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="HelpCommand"/> class.
     /// </summary>
@@ -60,8 +71,7 @@ public sealed class HelpCommand : ICommand
                 return Task.FromResult(CommandResult.Ok());
             }
 
-            context.Output.WriteLine($"[bold]{command.Name}[/] - {command.Description}");
-            context.Output.WriteLine($"[{theme.DimColor}]Usage:[/] {command.Usage}");
+            CommandHelpRenderer.Render(command, context.Output, theme);
             return Task.FromResult(CommandResult.Ok());
         }
 

--- a/src/NimbusStation.Cli/Commands/InfoCommand.cs
+++ b/src/NimbusStation.Cli/Commands/InfoCommand.cs
@@ -24,6 +24,16 @@ public sealed class InfoCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands { get; } = new HashSet<string>();
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Examples =
+        [
+            new("info", "Show details for the active cosmos and blob context")
+        ],
+        Notes = "Requires an active session with at least one resource context set."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InfoCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/SessionCommand.cs
+++ b/src/NimbusStation.Cli/Commands/SessionCommand.cs
@@ -32,6 +32,27 @@ public sealed class SessionCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("start <name>", "Start or resume a session"),
+            new("list, ls", "List all sessions"),
+            new("leave", "Leave the active session"),
+            new("resume <name>", "Resume an existing session"),
+            new("delete, rm <name>", "Delete a session and its data"),
+            new("status", "Show active session details")
+        ],
+        Examples =
+        [
+            new("session start GH-123", "Start investigating issue #123"),
+            new("session list", "View all sessions"),
+            new("session status", "Show current session details")
+        ],
+        Notes = "Sessions persist state, history, and artifacts to ~/.nimbus/sessions/."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/ThemeCommand.cs
+++ b/src/NimbusStation.Cli/Commands/ThemeCommand.cs
@@ -26,6 +26,24 @@ public sealed class ThemeCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("list, ls, presets", "List available themes"),
+            new("preview <name>", "Preview a theme's colors"),
+            new("current", "Show the current theme configuration")
+        ],
+        Examples =
+        [
+            new("theme list", "View available themes"),
+            new("theme preview monokai", "Preview the monokai theme"),
+            new("theme current", "Show active theme colors")
+        ],
+        Notes = "Configure your theme in ~/.config/nimbus/config.toml under [theme]."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ThemeCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Commands/UseCommand.cs
+++ b/src/NimbusStation.Cli/Commands/UseCommand.cs
@@ -29,6 +29,26 @@ public sealed class UseCommand : ICommand
     /// <inheritdoc/>
     public IReadOnlySet<string> Subcommands => _subcommands;
 
+    /// <inheritdoc/>
+    public CommandHelpMetadata HelpMetadata { get; } = new()
+    {
+        Subcommands =
+        [
+            new("cosmos <alias>", "Set active Cosmos DB context"),
+            new("blob <alias>", "Set active Blob Storage context"),
+            new("storage <alias>", "Set active Storage Account context"),
+            new("clear [provider]", "Clear active context (all or specific provider)")
+        ],
+        Examples =
+        [
+            new("use cosmos prod-db", "Activate the prod-db cosmos alias"),
+            new("use blob logs-store", "Activate the logs-store blob alias"),
+            new("use clear", "Clear all active contexts"),
+            new("use clear cosmos", "Clear only the cosmos context")
+        ],
+        Notes = "When no alias is given, launches an interactive browser to select one."
+    };
+
     /// <summary>
     /// Initializes a new instance of the <see cref="UseCommand"/> class.
     /// </summary>

--- a/src/NimbusStation.Cli/Output/CommandHelpRenderer.cs
+++ b/src/NimbusStation.Cli/Output/CommandHelpRenderer.cs
@@ -1,0 +1,66 @@
+using NimbusStation.Core.Commands;
+using NimbusStation.Core.Output;
+using NimbusStation.Infrastructure.Configuration;
+using Spectre.Console;
+
+namespace NimbusStation.Cli.Output;
+
+/// <summary>
+/// Renders TLDR-style inline help for commands using structured <see cref="CommandHelpMetadata"/>.
+/// </summary>
+public static class CommandHelpRenderer
+{
+    /// <summary>
+    /// Renders help for a command to the given output writer.
+    /// When the command has <see cref="ICommand.HelpMetadata"/>, renders rich structured help.
+    /// Otherwise falls back to basic name, description, and usage.
+    /// </summary>
+    public static void Render(ICommand command, IOutputWriter output, ThemeConfig theme)
+    {
+        output.WriteLine($"[bold]{Markup.Escape(command.Name)}[/] - {Markup.Escape(command.Description)}");
+        output.WriteLine($"[{theme.DimColor}]Usage:[/] {Markup.Escape(command.Usage)}");
+
+        var metadata = command.HelpMetadata;
+        if (metadata is null)
+            return;
+
+        if (metadata.Subcommands.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("[bold]Subcommands:[/]");
+            RenderEntries(metadata.Subcommands, output, theme);
+        }
+
+        if (metadata.Flags.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("[bold]Flags:[/]");
+            RenderEntries(metadata.Flags, output, theme);
+        }
+
+        if (metadata.Examples.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("[bold]Examples:[/]");
+            RenderEntries(metadata.Examples, output, theme);
+        }
+
+        if (metadata.Notes is not null)
+        {
+            output.WriteLine();
+            output.WriteLine($"[{theme.DimColor}]{Markup.Escape(metadata.Notes)}[/]");
+        }
+    }
+
+    private static void RenderEntries(IReadOnlyList<HelpEntry> entries, IOutputWriter output, ThemeConfig theme)
+    {
+        int maxLabelWidth = entries.Max(e => e.Label.Length);
+        int padding = maxLabelWidth + 4;
+
+        foreach (var entry in entries)
+        {
+            string paddedLabel = entry.Label.PadRight(padding);
+            output.WriteLine($"  [{theme.TableHeaderColor}]{Markup.Escape(paddedLabel)}[/]{Markup.Escape(entry.Description)}");
+        }
+    }
+}

--- a/src/NimbusStation.Cli/Repl/ReplLoop.cs
+++ b/src/NimbusStation.Cli/Repl/ReplLoop.cs
@@ -304,9 +304,6 @@ public sealed class ReplLoop
         if (command is null)
             return CommandResult.Error($"Unknown command: {commandName}");
 
-        if (!command.CanBePiped)
-            return CommandResult.Error($"Cannot pipe '{commandName}' command");
-
         var args = InputParser.GetArguments(tokens);
 
         if (args.Any(a => a is "--help" or "-h"))
@@ -315,6 +312,9 @@ public sealed class ReplLoop
             CommandHelpRenderer.Render(command, outputWriter, theme);
             return CommandResult.Ok();
         }
+
+        if (!command.CanBePiped)
+            return CommandResult.Error($"Cannot pipe '{commandName}' command");
 
         var context = new CommandContext(_sessionStateManager, outputWriter, _globalOptions);
 

--- a/src/NimbusStation.Cli/Repl/ReplLoop.cs
+++ b/src/NimbusStation.Cli/Repl/ReplLoop.cs
@@ -176,6 +176,14 @@ public sealed class ReplLoop
             try
             {
                 var args = InputParser.GetArguments(tokens);
+
+                if (args.Any(a => a is "--help" or "-h"))
+                {
+                    var theme = _configurationService.GetTheme();
+                    CommandHelpRenderer.Render(command, _outputWriter, theme);
+                    continue;
+                }
+
                 var context = new CommandContext(_sessionStateManager, _outputWriter, _globalOptions);
                 var result = await command.ExecuteAsync(args, context, cancellationToken);
 
@@ -300,6 +308,14 @@ public sealed class ReplLoop
             return CommandResult.Error($"Cannot pipe '{commandName}' command");
 
         var args = InputParser.GetArguments(tokens);
+
+        if (args.Any(a => a is "--help" or "-h"))
+        {
+            var theme = _configurationService.GetTheme();
+            CommandHelpRenderer.Render(command, outputWriter, theme);
+            return CommandResult.Ok();
+        }
+
         var context = new CommandContext(_sessionStateManager, outputWriter, _globalOptions);
 
         return await command.ExecuteAsync(args, context, cancellationToken);

--- a/src/NimbusStation.Core/Commands/CommandHelpMetadata.cs
+++ b/src/NimbusStation.Core/Commands/CommandHelpMetadata.cs
@@ -1,0 +1,28 @@
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// Structured help metadata for a command, used by the help renderer
+/// to produce TLDR-style inline help.
+/// </summary>
+public sealed record CommandHelpMetadata
+{
+    /// <summary>
+    /// Gets the available subcommands for this command.
+    /// </summary>
+    public IReadOnlyList<HelpEntry> Subcommands { get; init; } = [];
+
+    /// <summary>
+    /// Gets the available flags for this command.
+    /// </summary>
+    public IReadOnlyList<HelpEntry> Flags { get; init; } = [];
+
+    /// <summary>
+    /// Gets usage examples for this command.
+    /// </summary>
+    public IReadOnlyList<HelpEntry> Examples { get; init; } = [];
+
+    /// <summary>
+    /// Gets optional notes displayed at the end of the help output.
+    /// </summary>
+    public string? Notes { get; init; }
+}

--- a/src/NimbusStation.Core/Commands/HelpEntry.cs
+++ b/src/NimbusStation.Core/Commands/HelpEntry.cs
@@ -1,0 +1,8 @@
+namespace NimbusStation.Core.Commands;
+
+/// <summary>
+/// A label + description pair used in structured help output.
+/// </summary>
+/// <param name="Label">The short label (e.g., subcommand name or flag).</param>
+/// <param name="Description">A brief description of the label.</param>
+public sealed record HelpEntry(string Label, string Description);

--- a/src/NimbusStation.Core/Commands/ICommand.cs
+++ b/src/NimbusStation.Core/Commands/ICommand.cs
@@ -39,6 +39,12 @@ public interface ICommand
     bool CanBePiped => true;
 
     /// <summary>
+    /// Gets structured help metadata for rich inline help rendering.
+    /// Returns null when the command has no structured help, falling back to basic name/description/usage.
+    /// </summary>
+    CommandHelpMetadata? HelpMetadata => null;
+
+    /// <summary>
     /// Executes the command with the given arguments.
     /// </summary>
     /// <param name="args">The arguments passed to the command (excluding the command name itself).</param>

--- a/src/NimbusStation.Tests/Cli/Commands/AuthCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/AuthCommandTests.cs
@@ -206,4 +206,7 @@ public sealed class AuthCommandTests
 
         Assert.True(result.Success);
     }
+
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/BlobCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/BlobCommandTests.cs
@@ -317,6 +317,9 @@ public sealed class BlobCommandTests
             .WithContext(new SessionContext(null, "prod-exports", null)));
     }
 
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
+
     private CommandContext CreateContextWithSession()
     {
         _sessionStateManager.ActivateSession(Session.Create("TEST-123"));

--- a/src/NimbusStation.Tests/Cli/Commands/BrowseCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/BrowseCommandTests.cs
@@ -97,4 +97,7 @@ public sealed class BrowseCommandTests
         Assert.False(result.Success);
         Assert.Contains("interactive terminal", result.Message);
     }
+
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/CosmosCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/CosmosCommandTests.cs
@@ -247,6 +247,9 @@ public sealed class CosmosCommandTests
         Assert.Contains("query", _command.Subcommands);
     }
 
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
+
     private void SetupValidCosmosContext()
     {
         _configurationService.AddCosmosAlias("prod-orders", new CosmosAliasConfig(

--- a/src/NimbusStation.Tests/Cli/Commands/ExitCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/ExitCommandTests.cs
@@ -82,4 +82,7 @@ public sealed class ExitCommandTests
 
     [Fact]
     public void CanBePiped_ReturnsFalse() => Assert.False(_command.CanBePiped);
+
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/HelpCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/HelpCommandTests.cs
@@ -112,6 +112,9 @@ public sealed class HelpCommandTests
     [Fact]
     public void CanBePiped_ReturnsFalse() => Assert.False(_command.CanBePiped);
 
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
+
     private sealed class TestCommand : ICommand
     {
         public string Name => "test";

--- a/src/NimbusStation.Tests/Cli/Commands/InfoCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/InfoCommandTests.cs
@@ -142,4 +142,7 @@ public sealed class InfoCommandTests
     {
         Assert.Equal("info", _command.Usage);
     }
+
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/ThemeCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/ThemeCommandTests.cs
@@ -229,4 +229,7 @@ public sealed class ThemeCommandTests
         Assert.Contains("theme", _outputWriter.GetOutput());
         Assert.Contains("preset", _outputWriter.GetOutput());
     }
+
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
 }

--- a/src/NimbusStation.Tests/Cli/Commands/UseCommandTests.cs
+++ b/src/NimbusStation.Tests/Cli/Commands/UseCommandTests.cs
@@ -253,6 +253,9 @@ public sealed class UseCommandTests
         Assert.Contains("clear", _command.Subcommands);
     }
 
+    [Fact]
+    public void HelpMetadata_IsNotNull() => Assert.NotNull(_command.HelpMetadata);
+
     private CommandContext CreateContextWithSession()
     {
         _sessionStateManager.ActivateSession(Session.Create("TEST-123"));

--- a/src/NimbusStation.Tests/Cli/Output/CommandHelpRendererTests.cs
+++ b/src/NimbusStation.Tests/Cli/Output/CommandHelpRendererTests.cs
@@ -1,0 +1,184 @@
+using NimbusStation.Cli.Output;
+using NimbusStation.Core.Commands;
+using NimbusStation.Infrastructure.Configuration;
+using NimbusStation.Infrastructure.Output;
+
+namespace NimbusStation.Tests.Cli.Output;
+
+public sealed class CommandHelpRendererTests
+{
+    private static readonly ThemeConfig DefaultTheme = ThemeConfig.Default;
+
+    [Fact]
+    public void Render_WithMetadata_IncludesCommandNameAndDescription()
+    {
+        var command = new FakeCommand(new CommandHelpMetadata());
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("fake", text);
+        Assert.Contains("A fake command", text);
+    }
+
+    [Fact]
+    public void Render_WithMetadata_IncludesUsage()
+    {
+        var command = new FakeCommand(new CommandHelpMetadata());
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        Assert.Contains("fake [args]", output.GetOutput());
+    }
+
+    [Fact]
+    public void Render_WithSubcommands_RendersSubcommandSection()
+    {
+        var metadata = new CommandHelpMetadata
+        {
+            Subcommands =
+            [
+                new("start <name>", "Start something"),
+                new("stop", "Stop something")
+            ]
+        };
+        var command = new FakeCommand(metadata);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("Subcommands", text);
+        Assert.Contains("start <name>", text);
+        Assert.Contains("Start something", text);
+        Assert.Contains("stop", text);
+        Assert.Contains("Stop something", text);
+    }
+
+    [Fact]
+    public void Render_WithFlags_RendersFlagSection()
+    {
+        var metadata = new CommandHelpMetadata
+        {
+            Flags =
+            [
+                new("--max-items N", "Limit results")
+            ]
+        };
+        var command = new FakeCommand(metadata);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("Flags", text);
+        Assert.Contains("--max-items N", text);
+        Assert.Contains("Limit results", text);
+    }
+
+    [Fact]
+    public void Render_WithExamples_RendersExampleSection()
+    {
+        var metadata = new CommandHelpMetadata
+        {
+            Examples =
+            [
+                new("fake start foo", "Start foo"),
+                new("fake stop", "Stop everything")
+            ]
+        };
+        var command = new FakeCommand(metadata);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("Examples", text);
+        Assert.Contains("fake start foo", text);
+        Assert.Contains("Start foo", text);
+    }
+
+    [Fact]
+    public void Render_WithNotes_RendersNotes()
+    {
+        var metadata = new CommandHelpMetadata
+        {
+            Notes = "Some important note."
+        };
+        var command = new FakeCommand(metadata);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        Assert.Contains("Some important note.", output.GetOutput());
+    }
+
+    [Fact]
+    public void Render_NullMetadata_RendersBasicHelpOnly()
+    {
+        var command = new FakeCommand(helpMetadata: null);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("fake", text);
+        Assert.Contains("A fake command", text);
+        Assert.Contains("fake [args]", text);
+        Assert.DoesNotContain("Subcommands", text);
+        Assert.DoesNotContain("Flags", text);
+        Assert.DoesNotContain("Examples", text);
+    }
+
+    [Fact]
+    public void Render_EmptyMetadata_RendersBasicHelpOnly()
+    {
+        var command = new FakeCommand(new CommandHelpMetadata());
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.Contains("fake", text);
+        Assert.DoesNotContain("Subcommands", text);
+        Assert.DoesNotContain("Flags", text);
+        Assert.DoesNotContain("Examples", text);
+    }
+
+    [Fact]
+    public void Render_PartialMetadata_RendersOnlyPopulatedSections()
+    {
+        var metadata = new CommandHelpMetadata
+        {
+            Examples =
+            [
+                new("fake run", "Run it")
+            ]
+        };
+        var command = new FakeCommand(metadata);
+        var output = new CaptureOutputWriter();
+
+        CommandHelpRenderer.Render(command, output, DefaultTheme);
+
+        var text = output.GetOutput();
+        Assert.DoesNotContain("Subcommands", text);
+        Assert.DoesNotContain("Flags", text);
+        Assert.Contains("Examples", text);
+        Assert.Contains("fake run", text);
+    }
+
+    private sealed class FakeCommand : ICommand
+    {
+        public string Name => "fake";
+        public string Description => "A fake command";
+        public string Usage => "fake [args]";
+        public CommandHelpMetadata? HelpMetadata { get; }
+
+        public FakeCommand(CommandHelpMetadata? helpMetadata) => HelpMetadata = helpMetadata;
+
+        public Task<CommandResult> ExecuteAsync(string[] args, CommandContext context, CancellationToken cancellationToken = default) =>
+            Task.FromResult(CommandResult.Ok());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` as a universal flag intercepted by the REPL loop before command execution, rendering TLDR-style inline help for any command
- Introduces `CommandHelpMetadata` (with subcommands, flags, examples, notes) on `ICommand` and a `CommandHelpRenderer` that both `--help` and `help <command>` share, so output is always identical
- All 11 commands now provide structured `HelpMetadata` with contextual subcommands, examples, and notes

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 982 tests pass
- [ ] Manual: `session --help` and `session -h` show rich help
- [ ] Manual: `help session` produces identical output to `session --help`
- [ ] Manual: `help` (no args) still shows the command table
- [ ] Manual: `cosmos --help` shows subcommands and `--max-items` flag
- [ ] Manual: `exit --help` shows minimal help with alias note
- [ ] Manual: `session --help | grep start` — piped help works